### PR TITLE
fix: resume audio after browser interrupts playback on background tab or mobile

### DIFF
--- a/src/__tests__/WaveformNavigator.visibility.test.tsx
+++ b/src/__tests__/WaveformNavigator.visibility.test.tsx
@@ -1,0 +1,245 @@
+import React from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import { vi, describe, beforeEach, afterEach, expect, it } from 'vitest';
+
+import WaveformNavigator from '../WaveformNavigator';
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function mockAudio() {
+	(global as any).Audio = function () {
+		const el = document.createElement('audio');
+		(window as any).__lastAudio = el;
+		return el;
+	};
+}
+
+async function waitForAudio() {
+	await waitFor(() => expect((window as any).__lastAudio).toBeTruthy());
+	return (window as any).__lastAudio as HTMLAudioElement;
+}
+
+/**
+ * Create a fresh vi.fn() spy as an own property on the element so it
+ * doesn't inherit or accumulate state from the shared prototype mock in setup.ts.
+ */
+function spyOnPlay(audioEl: HTMLAudioElement) {
+	const spy = vi.fn().mockResolvedValue(undefined);
+	Object.defineProperty(audioEl, 'play', { value: spy, configurable: true });
+	return spy;
+}
+
+function setHidden(hidden: boolean) {
+	Object.defineProperty(document, 'hidden', { value: hidden, configurable: true });
+	document.dispatchEvent(new Event('visibilitychange'));
+}
+
+function dispatchPageShow(persisted: boolean) {
+	const ev = new Event('pageshow') as PageTransitionEvent;
+	Object.defineProperty(ev, 'persisted', { value: persisted });
+	window.dispatchEvent(ev);
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+describe('WaveformNavigator – visibility / bfcache resume', () => {
+	const origAudio = (global as any).Audio;
+	const origHidden = Object.getOwnPropertyDescriptor(document, 'hidden');
+
+	beforeEach(() => {
+		Object.defineProperty(document, 'hidden', { value: false, configurable: true });
+	});
+
+	afterEach(() => {
+		(global as any).Audio = origAudio;
+		(window as any).__lastAudio = undefined;
+		if (origHidden) {
+			Object.defineProperty(document, 'hidden', origHidden);
+		}
+	});
+
+	it('resumes playback when the tab becomes visible after the browser paused it', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		const playSpy = spyOnPlay(audioEl);
+
+		// Simulate audio playing
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		// Tab goes hidden while audio is playing
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// Browser pauses the audio (e.g. Safari background-tab policy)
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('pause'));
+		});
+
+		// Tab becomes visible again
+		await act(async () => {
+			setHidden(false);
+		});
+
+		expect(playSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not resume when audio was already paused before the tab was hidden', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		const playSpy = spyOnPlay(audioEl);
+
+		// Audio is never played — isPlaying stays false
+		await act(async () => {
+			setHidden(true);
+		});
+
+		await act(async () => {
+			setHidden(false);
+		});
+
+		expect(playSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not call play() when audio is still playing on tab return (desktop browsers)', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		const playSpy = spyOnPlay(audioEl);
+
+		// Simulate playing
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		// Tab goes hidden
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// Audio keeps playing in background (Chrome / Firefox) — no pause event.
+		// Override el.paused to reflect the element is not paused.
+		Object.defineProperty(audioEl, 'paused', {
+			get: () => false,
+			configurable: true,
+		});
+
+		// Tab becomes visible; el.paused is false, so no resume needed
+		await act(async () => {
+			setHidden(false);
+		});
+
+		expect(playSpy).not.toHaveBeenCalled();
+	});
+
+	it('restores currentTime when browser resets it to 0 on visibility return', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		spyOnPlay(audioEl);
+
+		// Simulate playing at 42 s
+		Object.defineProperty(audioEl, 'currentTime', {
+			value: 42,
+			writable: true,
+			configurable: true,
+		});
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+			audioEl.dispatchEvent(new Event('timeupdate'));
+		});
+
+		// Tab goes hidden (position saved)
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// Browser pauses and resets position (bfcache-style reset)
+		Object.defineProperty(audioEl, 'currentTime', {
+			value: 0,
+			writable: true,
+			configurable: true,
+		});
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('pause'));
+		});
+
+		// Tab becomes visible
+		await act(async () => {
+			setHidden(false);
+		});
+
+		expect(audioEl.currentTime).toBe(42);
+	});
+
+	it('resumes via pageshow with persisted=true (bfcache restore)', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		const playSpy = spyOnPlay(audioEl);
+
+		// Simulate playing
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		// Page goes hidden before being frozen into bfcache
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// Browser pauses audio
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('pause'));
+		});
+
+		// Page restored from bfcache
+		await act(async () => {
+			dispatchPageShow(true);
+		});
+
+		expect(playSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not resume via pageshow when persisted=false (normal navigation)', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		const playSpy = spyOnPlay(audioEl);
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		await act(async () => {
+			setHidden(true);
+		});
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('pause'));
+		});
+
+		// Normal (non-bfcache) pageshow
+		await act(async () => {
+			dispatchPageShow(false);
+		});
+
+		expect(playSpy).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -258,14 +258,15 @@ export function useAudioPlayer({
 				wasPlayingBeforeHiddenRef.current = isPlayingRef.current;
 				savedTimeBeforeHiddenRef.current = el.currentTime;
 			} else if (wasPlayingBeforeHiddenRef.current && el.paused) {
-				// Some browsers (Safari) reset currentTime to 0 after bfcache restore
-				if (
-					!isControlledRef.current &&
-					el.currentTime === 0 &&
-					savedTimeBeforeHiddenRef.current > 0
-				) {
+				// Some browsers (Safari) reset currentTime to 0 after bfcache restore.
+				// Restore position in both uncontrolled and controlled modes — in controlled
+				// mode the parent's controlledCurrentTime is unchanged so the sync effect
+				// won't re-run, leaving the audio element at 0 when play() is called.
+				if (el.currentTime === 0 && savedTimeBeforeHiddenRef.current > 0) {
 					el.currentTime = savedTimeBeforeHiddenRef.current;
-					setCurrentTime(savedTimeBeforeHiddenRef.current);
+					if (!isControlledRef.current) {
+						setCurrentTime(savedTimeBeforeHiddenRef.current);
+					}
 				}
 				el.play().catch(() => {});
 			}
@@ -279,13 +280,11 @@ export function useAudioPlayer({
 			if (!el) return;
 
 			if (wasPlayingBeforeHiddenRef.current && el.paused) {
-				if (
-					!isControlledRef.current &&
-					el.currentTime === 0 &&
-					savedTimeBeforeHiddenRef.current > 0
-				) {
+				if (el.currentTime === 0 && savedTimeBeforeHiddenRef.current > 0) {
 					el.currentTime = savedTimeBeforeHiddenRef.current;
-					setCurrentTime(savedTimeBeforeHiddenRef.current);
+					if (!isControlledRef.current) {
+						setCurrentTime(savedTimeBeforeHiddenRef.current);
+					}
 				}
 				el.play().catch(() => {});
 			}

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -101,6 +101,10 @@ export function useAudioPlayer({
 	const onErrorRef = useRef(onError);
 
 	useEffect(() => {
+		isPlayingRef.current = isPlaying;
+	}, [isPlaying]);
+
+	useEffect(() => {
 		onPlayRef.current = onPlay;
 		onPauseRef.current = onPause;
 		onEndedRef.current = onEnded;
@@ -119,6 +123,11 @@ export function useAudioPlayer({
 		onLoadingChange,
 		onError,
 	]);
+
+	// Track playback state across visibility changes / bfcache restores
+	const isPlayingRef = useRef(false);
+	const wasPlayingBeforeHiddenRef = useRef(false);
+	const savedTimeBeforeHiddenRef = useRef(0);
 
 	// Determine if component is in controlled mode
 	const isControlled = controlledCurrentTime !== undefined;
@@ -235,6 +244,60 @@ export function useAudioPlayer({
 			}
 		};
 		// audioElementRef is intentionally excluded from deps to avoid recreating audio element
+	}, []);
+
+	// Resume audio after the browser interrupts it (Safari background-tab pause,
+	// mobile screen lock, bfcache restore). Saves playing state on hide and
+	// re-calls play() when the page/tab becomes visible again.
+	useEffect(() => {
+		const handleVisibilityChange = () => {
+			const el = audioRef.current;
+			if (!el) return;
+
+			if (document.hidden) {
+				wasPlayingBeforeHiddenRef.current = isPlayingRef.current;
+				savedTimeBeforeHiddenRef.current = el.currentTime;
+			} else if (wasPlayingBeforeHiddenRef.current && el.paused) {
+				// Some browsers (Safari) reset currentTime to 0 after bfcache restore
+				if (
+					!isControlledRef.current &&
+					el.currentTime === 0 &&
+					savedTimeBeforeHiddenRef.current > 0
+				) {
+					el.currentTime = savedTimeBeforeHiddenRef.current;
+					setCurrentTime(savedTimeBeforeHiddenRef.current);
+				}
+				el.play().catch(() => {});
+			}
+		};
+
+		// pageshow fires with persisted=true when the page is restored from bfcache
+		// (common on mobile Safari). visibilitychange may not fire in that path.
+		const handlePageShow = (event: PageTransitionEvent) => {
+			if (!event.persisted) return;
+			const el = audioRef.current;
+			if (!el) return;
+
+			if (wasPlayingBeforeHiddenRef.current && el.paused) {
+				if (
+					!isControlledRef.current &&
+					el.currentTime === 0 &&
+					savedTimeBeforeHiddenRef.current > 0
+				) {
+					el.currentTime = savedTimeBeforeHiddenRef.current;
+					setCurrentTime(savedTimeBeforeHiddenRef.current);
+				}
+				el.play().catch(() => {});
+			}
+		};
+
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+		window.addEventListener('pageshow', handlePageShow);
+
+		return () => {
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
+			window.removeEventListener('pageshow', handlePageShow);
+		};
 	}, []);
 
 	// When a Blob URL derived from the waveform fetch is available, point the

--- a/src/hooks/useWaveformCanvas.ts
+++ b/src/hooks/useWaveformCanvas.ts
@@ -286,13 +286,14 @@ export function useWaveformCanvas({
 		readyDispatchedRef.current = false;
 	}, [peaks, barWidth, gap, barColor, backgroundColor]);
 
-	// Smooth progress updates while playing using requestAnimationFrame
+	// Smooth progress updates while playing using requestAnimationFrame.
+	// currentTime is intentionally excluded — the loop reads currentTimeRef.current
+	// directly so it always has the latest value without restarting on every timeupdate.
 	useEffect(() => {
 		function loop() {
 			const currentPeaks = peaksRef.current;
-			const currentTimeValue = currentTimeRef.current;
 			if (currentPeaks) {
-				drawWaveform(currentPeaks, currentTimeValue);
+				drawWaveform(currentPeaks, currentTimeRef.current);
 				rafRef.current = window.requestAnimationFrame(loop);
 			}
 		}
@@ -305,10 +306,6 @@ export function useWaveformCanvas({
 				window.cancelAnimationFrame(rafRef.current);
 				rafRef.current = null;
 			}
-			// Draw once when paused - will build and cache if needed
-			if (peaks) {
-				drawWaveform(peaks, currentTime);
-			}
 		}
 
 		return () => {
@@ -317,16 +314,14 @@ export function useWaveformCanvas({
 				rafRef.current = null;
 			}
 		};
-	}, [
-		isPlaying,
-		peaks,
-		progressColor,
-		playheadColor,
-		markerColor,
-		markerLabelColor,
-		markers,
-		currentTime,
-	]);
+	}, [isPlaying, peaks, progressColor, playheadColor, markerColor, markerLabelColor, markers]);
+
+	// When paused, redraw on seek (currentTime change) or on transition to paused state.
+	useEffect(() => {
+		if (!isPlaying && peaks) {
+			drawWaveform(peaks, currentTime);
+		}
+	}, [currentTime, isPlaying, peaks]);
 
 	return {
 		canvasRef,

--- a/src/hooks/useWaveformCanvas.ts
+++ b/src/hooks/useWaveformCanvas.ts
@@ -316,12 +316,14 @@ export function useWaveformCanvas({
 		};
 	}, [isPlaying, peaks, progressColor, playheadColor, markerColor, markerLabelColor, markers]);
 
-	// When paused, redraw on seek (currentTime change) or on transition to paused state.
+	// When paused, redraw on seek or whenever any visual prop changes.
+	// Mirrors the deps the original combined effect used for the non-playing branch,
+	// restoring immediate canvas updates when e.g. progressColor or markers change.
 	useEffect(() => {
 		if (!isPlaying && peaks) {
 			drawWaveform(peaks, currentTime);
 		}
-	}, [currentTime, isPlaying, peaks]);
+	}, [currentTime, isPlaying, peaks, progressColor, playheadColor, markerColor, markerLabelColor, markers]);
 
 	return {
 		canvasRef,


### PR DESCRIPTION
Add visibilitychange and pageshow handlers to useAudioPlayer so audio
automatically resumes when the user returns to a hidden tab or a page
restored from bfcache. Saves playing state and currentTime on hide;
restores position if the browser reset it to 0 (e.g. iOS bfcache),
then calls play() only when the element was genuinely paused by the
browser rather than by the user.

Also remove currentTime from the RAF effect's dependency array in
useWaveformCanvas. Including it caused the animation loop to cancel
and restart on every timeupdate (~every 250 ms), skipping one rendered
frame per cycle. The loop already reads currentTimeRef.current directly,
so the dependency was redundant. A separate effect now handles the
single static redraw needed when seeking while paused.

https://claude.ai/code/session_011MpoZe5ykoMU8pfNynt2kE