### PR TITLE
bug: reconcile UI state with media element state

### DIFF
--- a/src/__tests__/WaveformNavigator.visibility.test.tsx
+++ b/src/__tests__/WaveformNavigator.visibility.test.tsx
@@ -432,6 +432,71 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		vi.useRealTimers();
 	});
 
+	it('keeps escalating recovery when UI is stuck in playing state but audio is paused on return', async () => {
+		vi.useFakeTimers();
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		// waitForAudio uses waitFor which relies on real timers, so we briefly
+		// restore them for setup, then re-enable fake timers for the assertion.
+		vi.useRealTimers();
+		const audioEl = await waitForAudio();
+		vi.useFakeTimers();
+
+		const playSpy = spyOnPlay(audioEl);
+
+		// Simulate playing and advancing time
+		Object.defineProperty(audioEl, 'currentTime', {
+			value: 12,
+			writable: true,
+			configurable: true,
+		});
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+			audioEl.dispatchEvent(new Event('timeupdate'));
+		});
+
+		// Tab hidden (position saved)
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// On return, simulate a pathological browser state:
+		// - React still thinks we are playing (no pause event delivered yet)
+		// - Element is actually paused and reset to start
+		Object.defineProperty(audioEl, 'paused', {
+			get: () => true,
+			configurable: true,
+		});
+		Object.defineProperty(audioEl, 'readyState', {
+			get: () => HTMLMediaElement.HAVE_CURRENT_DATA, // 2 — stalled
+			configurable: true,
+		});
+		Object.defineProperty(audioEl, 'currentTime', {
+			value: 0,
+			writable: true,
+			configurable: true,
+		});
+
+		// Visible again: should trigger recovery attempt 1 immediately
+		await act(async () => {
+			setHidden(false);
+		});
+
+		// Advance timers to allow escalations (attempts 2 and 3) to run.
+		await act(async () => {
+			vi.advanceTimersByTime(1500);
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(1500);
+		});
+
+		// Should attempt play multiple times despite the stale React "playing" state.
+		expect(playSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+		vi.useRealTimers();
+	});
+
 	it('does not trigger recovery when playback was not active before hidden', async () => {
 		mockAudio();
 

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -330,8 +330,10 @@ export function useAudioPlayer({
 			const scheduleNext = () => {
 				recoveryTimerRef.current = setTimeout(() => {
 					recoveryTimerRef.current = null;
-					// Abort if playback resumed naturally or user hid the tab again
-					if (isPlayingRef.current || !wasPlayingBeforeHiddenRef.current) return;
+					// Abort if user paused or the tab was hidden again.
+					// Do not gate on React `isPlaying` state — it can be stale after
+					// background interruptions. Instead, rely on the element's real state.
+					if (!wasPlayingBeforeHiddenRef.current) return;
 					const currentEl = audioRef.current;
 					if (!currentEl || !isStalled(currentEl)) return;
 					recoverPlayback(currentEl, savedTime);
@@ -402,6 +404,14 @@ export function useAudioPlayer({
 				}
 				if (isStalled(el)) {
 					recoverPlayback(el, savedTimeBeforeHiddenRef.current);
+				}
+				// Reconcile UI state with the element on return: browsers can pause or
+				// reset media while hidden without delivering events in a timely order.
+				// This keeps the play/pause button from getting stuck showing "pause"
+				// while the element is actually paused.
+				const shouldBePlaying = !el.paused && !el.ended;
+				if (isPlayingRef.current !== shouldBePlaying) {
+					setIsPlaying(shouldBePlaying);
 				}
 			}
 		};

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -394,17 +394,6 @@ export function useAudioPlayer({
 				}
 				recoveryAttemptsRef.current = 0;
 			} else if (wasPlayingBeforeHiddenRef.current) {
-				const progressedWhileHidden =
-					el.currentTime >
-					savedTimeBeforeHiddenRef.current + CONTROLLED_TIME_THRESHOLD;
-				if (progressedWhileHidden) {
-					lastTimeupdateWallClockRef.current = Date.now();
-					recoveryAttemptsRef.current = 0;
-					return;
-				}
-				if (isStalled(el)) {
-					recoverPlayback(el, savedTimeBeforeHiddenRef.current);
-				}
 				// Reconcile UI state with the element on return: browsers can pause or
 				// reset media while hidden without delivering events in a timely order.
 				// This keeps the play/pause button from getting stuck showing "pause"
@@ -412,6 +401,29 @@ export function useAudioPlayer({
 				const shouldBePlaying = !el.paused && !el.ended;
 				if (isPlayingRef.current !== shouldBePlaying) {
 					setIsPlaying(shouldBePlaying);
+				}
+
+				const progressedWhileHidden =
+					el.currentTime >
+					savedTimeBeforeHiddenRef.current + CONTROLLED_TIME_THRESHOLD;
+				// If the media clearly advanced while hidden and is not stalled on return,
+				// don't force recovery — desktop browsers often suppress timeupdate in
+				// background tabs even though playback is healthy.
+				// Important: check this before applying the wall-clock stall heuristic,
+				// otherwise long hidden intervals can look like a stall even when media
+				// advanced normally.
+				if (
+					progressedWhileHidden &&
+					!el.paused &&
+					el.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA
+				) {
+					lastTimeupdateWallClockRef.current = Date.now();
+					recoveryAttemptsRef.current = 0;
+					return;
+				}
+				const stalled = isStalled(el);
+				if (stalled) {
+					recoverPlayback(el, savedTimeBeforeHiddenRef.current);
 				}
 			}
 		};


### PR DESCRIPTION
- Implemented a new test to verify that the audio player correctly escalates recovery attempts when the UI is in a playing state but the audio is paused upon returning from a hidden tab.
- Updated the audio player hook to reconcile UI state with the actual media element state, ensuring accurate play/pause button behavior after background interruptions.