### PR TITLE
bug: fix playback sync issues with underlying audio element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "waveform-navigator",
-	"version": "0.2.3",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "waveform-navigator",
-			"version": "0.2.3",
+			"version": "0.3.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@axe-core/playwright": "^4.11.0",

--- a/src/__tests__/WaveformNavigator.visibility.test.tsx
+++ b/src/__tests__/WaveformNavigator.visibility.test.tsx
@@ -572,6 +572,140 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		).toBe('play');
 	});
 
+	it('cancels in-flight reload when the audio source changes mid-resume', async () => {
+		mockAudio();
+
+		const { rerender } = render(
+			<WaveformNavigator audio="/test.mp3" responsive={false} />
+		);
+
+		const audioEl = await waitForAudio();
+
+		// play() always rejects so the reload path is entered. Reload (load())
+		// is deferred so we can swap the audio source while it's pending.
+		const playSpy = vi.fn().mockRejectedValue(new Error('NotAllowedError'));
+		Object.defineProperty(audioEl, 'play', {
+			value: playSpy,
+			configurable: true,
+		});
+
+		let resolveCanPlay: (() => void) | null = null;
+		const loadSpy = vi.fn(() => {
+			// Delay firing canplay until the source change has aborted the resume;
+			// when we eventually fire it, the resume must be a no-op.
+			resolveCanPlay = () => audioEl.dispatchEvent(new Event('canplay'));
+		});
+		Object.defineProperty(audioEl, 'load', {
+			value: loadSpy,
+			configurable: true,
+		});
+		Object.defineProperty(audioEl, 'currentSrc', {
+			get: () => '/test.mp3',
+			configurable: true,
+		});
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		await act(async () => {
+			setHidden(true);
+		});
+
+		definePaused(audioEl, true);
+
+		await act(async () => {
+			setHidden(false);
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// First play() rejected, reload started.
+		expect(loadSpy).toHaveBeenCalledTimes(1);
+		expect(playSpy).toHaveBeenCalledTimes(1);
+
+		// Now swap the audio source — this must abort the in-flight resume.
+		await act(async () => {
+			rerender(<WaveformNavigator audio="/other.mp3" responsive={false} />);
+		});
+
+		// Even if canplay fires now, the aborted resume must not call play() again.
+		await act(async () => {
+			resolveCanPlay?.();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(playSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('emits onLoadingChange(false) when syncing on visibility return', async () => {
+		mockAudio();
+
+		const onLoadingChange = vi.fn();
+		render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				onLoadingChange={onLoadingChange}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		spyOnPlay(audioEl);
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// Element keeps playing while hidden — no resume needed, only a sync.
+		definePaused(audioEl, false);
+		onLoadingChange.mockClear();
+
+		await act(async () => {
+			setHidden(false);
+		});
+
+		expect(onLoadingChange).toHaveBeenCalledWith(false);
+	});
+
+	it('resets currentTime to 0 when the audio element fires emptied', async () => {
+		mockAudio();
+
+		const onTimeUpdate = vi.fn();
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				onTimeUpdate={onTimeUpdate}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		spyOnPlay(audioEl);
+
+		// Advance to 30s.
+		defineCurrentTime(audioEl, 30);
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+			audioEl.dispatchEvent(new Event('timeupdate'));
+		});
+
+		// Browser evicts the media → emptied fires (currentTime resets to 0).
+		defineCurrentTime(audioEl, 0);
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('emptied'));
+		});
+
+		// Time display must show 0:00 / … — i.e. the React currentTime is 0.
+		const timeText = container.querySelector('.time')?.textContent ?? '';
+		expect(timeText.startsWith('0:00')).toBe(true);
+	});
+
 	it('resumes via window focus when visibilitychange is not fired (window switch)', async () => {
 		mockAudio();
 

--- a/src/__tests__/WaveformNavigator.visibility.test.tsx
+++ b/src/__tests__/WaveformNavigator.visibility.test.tsx
@@ -43,6 +43,21 @@ function dispatchPageShow(persisted: boolean) {
 	window.dispatchEvent(ev);
 }
 
+function definePaused(audioEl: HTMLAudioElement, paused: boolean) {
+	Object.defineProperty(audioEl, 'paused', {
+		get: () => paused,
+		configurable: true,
+	});
+}
+
+function defineCurrentTime(audioEl: HTMLAudioElement, time: number) {
+	Object.defineProperty(audioEl, 'currentTime', {
+		value: time,
+		writable: true,
+		configurable: true,
+	});
+}
+
 // ─── tests ───────────────────────────────────────────────────────────────────
 
 describe('WaveformNavigator – visibility / bfcache resume', () => {
@@ -72,12 +87,10 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		const audioEl = await waitForAudio();
 		const playSpy = spyOnPlay(audioEl);
 
-		// Simulate audio playing
 		await act(async () => {
 			audioEl.dispatchEvent(new Event('play'));
 		});
 
-		// Tab goes hidden while audio is playing
 		await act(async () => {
 			setHidden(true);
 		});
@@ -87,7 +100,6 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 			audioEl.dispatchEvent(new Event('pause'));
 		});
 
-		// Tab becomes visible again
 		await act(async () => {
 			setHidden(false);
 		});
@@ -103,7 +115,6 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		const audioEl = await waitForAudio();
 		const playSpy = spyOnPlay(audioEl);
 
-		// Audio is never played — isPlaying stays false
 		await act(async () => {
 			setHidden(true);
 		});
@@ -123,28 +134,17 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		const audioEl = await waitForAudio();
 		const playSpy = spyOnPlay(audioEl);
 
-		// Simulate playing
 		await act(async () => {
 			audioEl.dispatchEvent(new Event('play'));
 		});
 
-		// Tab goes hidden
 		await act(async () => {
 			setHidden(true);
 		});
 
 		// Audio keeps playing in background (Chrome / Firefox) — no pause event.
-		// Override el.paused and el.readyState to reflect healthy playback.
-		Object.defineProperty(audioEl, 'paused', {
-			get: () => false,
-			configurable: true,
-		});
-		Object.defineProperty(audioEl, 'readyState', {
-			get: () => HTMLMediaElement.HAVE_ENOUGH_DATA, // 4 — fully healthy
-			configurable: true,
-		});
+		definePaused(audioEl, false);
 
-		// Tab becomes visible; el is not stalled, so no resume needed
 		await act(async () => {
 			setHidden(false);
 		});
@@ -153,21 +153,14 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 	});
 
 	it('does not force recovery when currentTime advanced while hidden without timeupdate events', async () => {
-		vi.useFakeTimers();
 		mockAudio();
 
 		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
 
-		vi.useRealTimers();
 		const audioEl = await waitForAudio();
-		vi.useFakeTimers();
 		const playSpy = spyOnPlay(audioEl);
 
-		Object.defineProperty(audioEl, 'currentTime', {
-			value: 10,
-			writable: true,
-			configurable: true,
-		});
+		defineCurrentTime(audioEl, 10);
 		await act(async () => {
 			audioEl.dispatchEvent(new Event('play'));
 			audioEl.dispatchEvent(new Event('timeupdate'));
@@ -177,30 +170,15 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 			setHidden(true);
 		});
 
-		Object.defineProperty(audioEl, 'paused', {
-			get: () => false,
-			configurable: true,
-		});
-		Object.defineProperty(audioEl, 'readyState', {
-			get: () => HTMLMediaElement.HAVE_ENOUGH_DATA,
-			configurable: true,
-		});
-		Object.defineProperty(audioEl, 'currentTime', {
-			value: 14,
-			writable: true,
-			configurable: true,
-		});
-
-		await act(async () => {
-			vi.advanceTimersByTime(5000);
-		});
+		// Element kept playing while hidden (desktop browsers don't pause).
+		definePaused(audioEl, false);
+		defineCurrentTime(audioEl, 14);
 
 		await act(async () => {
 			setHidden(false);
 		});
 
 		expect(playSpy).not.toHaveBeenCalled();
-		vi.useRealTimers();
 	});
 
 	it('restores currentTime when browser resets it to 0 on visibility return', async () => {
@@ -211,38 +189,58 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		const audioEl = await waitForAudio();
 		spyOnPlay(audioEl);
 
-		// Simulate playing at 42 s
-		Object.defineProperty(audioEl, 'currentTime', {
-			value: 42,
-			writable: true,
-			configurable: true,
-		});
+		defineCurrentTime(audioEl, 42);
 		await act(async () => {
 			audioEl.dispatchEvent(new Event('play'));
 			audioEl.dispatchEvent(new Event('timeupdate'));
 		});
 
-		// Tab goes hidden (position saved)
 		await act(async () => {
 			setHidden(true);
 		});
 
 		// Browser pauses and resets position (bfcache-style reset)
-		Object.defineProperty(audioEl, 'currentTime', {
-			value: 0,
-			writable: true,
-			configurable: true,
-		});
+		defineCurrentTime(audioEl, 0);
 		await act(async () => {
 			audioEl.dispatchEvent(new Event('pause'));
 		});
 
-		// Tab becomes visible
 		await act(async () => {
 			setHidden(false);
 		});
 
 		expect(audioEl.currentTime).toBe(42);
+	});
+
+	it('also restores currentTime when browser resets it to a tiny non-zero value', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		spyOnPlay(audioEl);
+
+		defineCurrentTime(audioEl, 30);
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+			audioEl.dispatchEvent(new Event('timeupdate'));
+		});
+
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// Some browsers drop currentTime to a small non-zero value during eviction.
+		defineCurrentTime(audioEl, 0.05);
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('pause'));
+		});
+
+		await act(async () => {
+			setHidden(false);
+		});
+
+		expect(audioEl.currentTime).toBe(30);
 	});
 
 	it('resumes via pageshow with persisted=true (bfcache restore)', async () => {
@@ -253,22 +251,18 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		const audioEl = await waitForAudio();
 		const playSpy = spyOnPlay(audioEl);
 
-		// Simulate playing
 		await act(async () => {
 			audioEl.dispatchEvent(new Event('play'));
 		});
 
-		// Page goes hidden before being frozen into bfcache
 		await act(async () => {
 			setHidden(true);
 		});
 
-		// Browser pauses audio
 		await act(async () => {
 			audioEl.dispatchEvent(new Event('pause'));
 		});
 
-		// Page restored from bfcache
 		await act(async () => {
 			dispatchPageShow(true);
 		});
@@ -296,205 +290,11 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 			audioEl.dispatchEvent(new Event('pause'));
 		});
 
-		// Normal (non-bfcache) pageshow
 		await act(async () => {
 			dispatchPageShow(false);
 		});
 
 		expect(playSpy).not.toHaveBeenCalled();
-	});
-
-	it('recovers when stalled but not paused on visibility return', async () => {
-		mockAudio();
-
-		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
-
-		const audioEl = await waitForAudio();
-		const playSpy = spyOnPlay(audioEl);
-
-		// Simulate audio playing
-		await act(async () => {
-			audioEl.dispatchEvent(new Event('play'));
-		});
-
-		// Tab goes hidden while playing
-		await act(async () => {
-			setHidden(true);
-		});
-
-		// Browser did NOT pause the audio (e.g. Chrome on Android), but it is
-		// stalled — paused=false yet readyState drops below HAVE_FUTURE_DATA (3).
-		Object.defineProperty(audioEl, 'paused', {
-			get: () => false,
-			configurable: true,
-		});
-		Object.defineProperty(audioEl, 'readyState', {
-			get: () => HTMLMediaElement.HAVE_CURRENT_DATA, // 2 — stalled
-			configurable: true,
-		});
-
-		// Tab becomes visible — isStalled() should be true → recovery fires
-		await act(async () => {
-			setHidden(false);
-		});
-
-		expect(playSpy).toHaveBeenCalledTimes(1);
-	});
-
-	it('respects MAX_RECOVERY_ATTEMPTS cap and does not loop indefinitely', async () => {
-		vi.useFakeTimers();
-
-		mockAudio();
-
-		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
-
-		// waitForAudio uses waitFor which relies on real timers, so we briefly
-		// restore them for setup, then re-enable fake timers for the assertion.
-		vi.useRealTimers();
-		const audioEl = await waitForAudio();
-		vi.useFakeTimers();
-
-		const playSpy = spyOnPlay(audioEl);
-
-		// Simulate playing
-		await act(async () => {
-			audioEl.dispatchEvent(new Event('play'));
-		});
-
-		// Tab hidden
-		await act(async () => {
-			setHidden(true);
-		});
-
-		// Keep element in a persistently stalled state (paused=true) so every
-		// escalation attempt still sees a stall and would fire another play()
-		// if there were no retry cap.
-		// el.paused defaults to true on a fresh audio element.
-
-		// Tab visible — first recovery attempt
-		await act(async () => {
-			setHidden(false);
-		});
-
-		// Advance through both escalation intervals to trigger attempts 2 and 3
-		await act(async () => {
-			vi.advanceTimersByTime(1500); // attempt 2
-		});
-		await act(async () => {
-			vi.advanceTimersByTime(1500); // attempt 3
-		});
-
-		// One more interval — must NOT trigger a 4th attempt
-		await act(async () => {
-			vi.advanceTimersByTime(1500);
-		});
-
-		// At most MAX_RECOVERY_ATTEMPTS (3) play() calls; never more
-		expect(playSpy.mock.calls.length).toBeLessThanOrEqual(3);
-
-		vi.useRealTimers();
-	});
-
-	it('stops scheduled recovery retries when user pauses during recovery', async () => {
-		vi.useFakeTimers();
-		mockAudio();
-
-		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
-
-		vi.useRealTimers();
-		const audioEl = await waitForAudio();
-		vi.useFakeTimers();
-		const playSpy = spyOnPlay(audioEl);
-
-		await act(async () => {
-			audioEl.dispatchEvent(new Event('play'));
-		});
-
-		await act(async () => {
-			setHidden(true);
-		});
-
-		await act(async () => {
-			setHidden(false);
-		});
-
-		expect(playSpy).toHaveBeenCalledTimes(1);
-
-		await act(async () => {
-			audioEl.dispatchEvent(new Event('pause'));
-		});
-
-		await act(async () => {
-			vi.advanceTimersByTime(5000);
-		});
-
-		expect(playSpy).toHaveBeenCalledTimes(1);
-		vi.useRealTimers();
-	});
-
-	it('keeps escalating recovery when UI is stuck in playing state but audio is paused on return', async () => {
-		vi.useFakeTimers();
-		mockAudio();
-
-		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
-
-		// waitForAudio uses waitFor which relies on real timers, so we briefly
-		// restore them for setup, then re-enable fake timers for the assertion.
-		vi.useRealTimers();
-		const audioEl = await waitForAudio();
-		vi.useFakeTimers();
-
-		const playSpy = spyOnPlay(audioEl);
-
-		// Simulate playing and advancing time
-		Object.defineProperty(audioEl, 'currentTime', {
-			value: 12,
-			writable: true,
-			configurable: true,
-		});
-		await act(async () => {
-			audioEl.dispatchEvent(new Event('play'));
-			audioEl.dispatchEvent(new Event('timeupdate'));
-		});
-
-		// Tab hidden (position saved)
-		await act(async () => {
-			setHidden(true);
-		});
-
-		// On return, simulate a pathological browser state:
-		// - React still thinks we are playing (no pause event delivered yet)
-		// - Element is actually paused and reset to start
-		Object.defineProperty(audioEl, 'paused', {
-			get: () => true,
-			configurable: true,
-		});
-		Object.defineProperty(audioEl, 'readyState', {
-			get: () => HTMLMediaElement.HAVE_CURRENT_DATA, // 2 — stalled
-			configurable: true,
-		});
-		Object.defineProperty(audioEl, 'currentTime', {
-			value: 0,
-			writable: true,
-			configurable: true,
-		});
-
-		// Visible again: should trigger recovery attempt 1 immediately
-		await act(async () => {
-			setHidden(false);
-		});
-
-		// Advance timers to allow escalations (attempts 2 and 3) to run.
-		await act(async () => {
-			vi.advanceTimersByTime(1500);
-		});
-		await act(async () => {
-			vi.advanceTimersByTime(1500);
-		});
-
-		// Should attempt play multiple times despite the stale React "playing" state.
-		expect(playSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
-		vi.useRealTimers();
 	});
 
 	it('does not trigger recovery when playback was not active before hidden', async () => {
@@ -505,9 +305,6 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		const audioEl = await waitForAudio();
 		const playSpy = spyOnPlay(audioEl);
 
-		// Audio is never played — wasPlayingBeforeHidden stays false
-
-		// Even though element is "stalled" (paused by default), no recovery fires
 		await act(async () => {
 			setHidden(true);
 		});
@@ -517,5 +314,292 @@ describe('WaveformNavigator – visibility / bfcache resume', () => {
 		});
 
 		expect(playSpy).not.toHaveBeenCalled();
+	});
+
+	// ─── new behaviour: reconcile UI to element on every return ─────────────────
+
+	it('syncs isPlaying=false on visibility return when element is paused', async () => {
+		mockAudio();
+
+		const onPause = vi.fn();
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				onPause={onPause}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		spyOnPlay(audioEl);
+
+		// Drive React into "playing" state.
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		expect(container.querySelector('button.play')?.getAttribute('aria-label')).toBe(
+			'pause'
+		);
+
+		await act(async () => {
+			setHidden(true);
+		});
+
+		// Simulate the pathological case: browser paused without firing pause,
+		// and the late pause event also clears wasPlayingBeforeHidden BEFORE
+		// visibility returns (race we previously failed to handle).
+		definePaused(audioEl, true);
+		defineCurrentTime(audioEl, 0);
+		// Clear intent so resumeIfNeeded won't fire — this isolates the sync.
+		await act(async () => {
+			Object.defineProperty(document, 'hidden', {
+				value: false,
+				configurable: true,
+			});
+			audioEl.dispatchEvent(new Event('pause'));
+		});
+
+		// Now dispatch visibilitychange to trigger sync; element is paused, so
+		// the button must reflect that even though no resume runs.
+		await act(async () => {
+			document.dispatchEvent(new Event('visibilitychange'));
+		});
+
+		expect(
+			container.querySelector('button.play')?.getAttribute('aria-label')
+		).toBe('play');
+	});
+
+	it('reloads source and resumes when first play() rejects on visibility return', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+
+		// First play() rejects; reload then succeeds.
+		const playSpy = vi
+			.fn()
+			.mockRejectedValueOnce(new Error('NotAllowedError'))
+			.mockResolvedValue(undefined);
+		Object.defineProperty(audioEl, 'play', {
+			value: playSpy,
+			configurable: true,
+		});
+
+		// load() triggers our canplay listener.
+		const loadSpy = vi.fn(() => {
+			queueMicrotask(() => audioEl.dispatchEvent(new Event('canplay')));
+		});
+		Object.defineProperty(audioEl, 'load', {
+			value: loadSpy,
+			configurable: true,
+		});
+		Object.defineProperty(audioEl, 'currentSrc', {
+			get: () => '/test.mp3',
+			configurable: true,
+		});
+
+		defineCurrentTime(audioEl, 20);
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+			audioEl.dispatchEvent(new Event('timeupdate'));
+		});
+
+		await act(async () => {
+			setHidden(true);
+		});
+
+		definePaused(audioEl, true);
+		defineCurrentTime(audioEl, 0);
+
+		await act(async () => {
+			setHidden(false);
+		});
+
+		// Let the reload pipeline drain.
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(loadSpy).toHaveBeenCalled();
+		expect(playSpy).toHaveBeenCalledTimes(2);
+	});
+
+	it('shows paused UI when reload also fails', async () => {
+		mockAudio();
+
+		const { container } = render(
+			<WaveformNavigator audio="/test.mp3" responsive={false} />
+		);
+
+		const audioEl = await waitForAudio();
+
+		const playSpy = vi.fn().mockRejectedValue(new Error('NotAllowedError'));
+		Object.defineProperty(audioEl, 'play', {
+			value: playSpy,
+			configurable: true,
+		});
+
+		// load() triggers an error to make the reload path fail.
+		Object.defineProperty(audioEl, 'load', {
+			value: vi.fn(() => {
+				queueMicrotask(() => audioEl.dispatchEvent(new Event('error')));
+			}),
+			configurable: true,
+		});
+		Object.defineProperty(audioEl, 'currentSrc', {
+			get: () => '/test.mp3',
+			configurable: true,
+		});
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		await act(async () => {
+			setHidden(true);
+		});
+
+		definePaused(audioEl, true);
+
+		await act(async () => {
+			setHidden(false);
+		});
+
+		await act(async () => {
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		// After both attempts fail, UI must reflect the paused element state.
+		expect(
+			container.querySelector('button.play')?.getAttribute('aria-label')
+		).toBe('play');
+	});
+
+	it('resets isPlaying when the audio element fires error', async () => {
+		mockAudio();
+
+		const { container } = render(
+			<WaveformNavigator audio="/test.mp3" responsive={false} />
+		);
+
+		const audioEl = await waitForAudio();
+		spyOnPlay(audioEl);
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		expect(container.querySelector('button.play')?.getAttribute('aria-label')).toBe(
+			'pause'
+		);
+
+		// Simulate a media error fired after play with no preceding pause event.
+		Object.defineProperty(audioEl, 'error', {
+			get: () => ({ code: 3 }), // MEDIA_ERR_DECODE
+			configurable: true,
+		});
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('error'));
+		});
+
+		expect(
+			container.querySelector('button.play')?.getAttribute('aria-label')
+		).toBe('play');
+	});
+
+	it('resets isPlaying when the audio element fires emptied', async () => {
+		mockAudio();
+
+		const { container } = render(
+			<WaveformNavigator audio="/test.mp3" responsive={false} />
+		);
+
+		const audioEl = await waitForAudio();
+		spyOnPlay(audioEl);
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		expect(container.querySelector('button.play')?.getAttribute('aria-label')).toBe(
+			'pause'
+		);
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('emptied'));
+		});
+
+		expect(
+			container.querySelector('button.play')?.getAttribute('aria-label')
+		).toBe('play');
+	});
+
+	it('resets isPlaying when togglePlay rejects', async () => {
+		mockAudio();
+
+		const { container } = render(
+			<WaveformNavigator audio="/test.mp3" responsive={false} />
+		);
+
+		const audioEl = await waitForAudio();
+		Object.defineProperty(audioEl, 'play', {
+			value: vi.fn().mockRejectedValue(new Error('NotAllowedError')),
+			configurable: true,
+		});
+
+		// Force the "playing" state without going through play() so togglePlay's
+		// catch branch is the only thing that can flip it back.
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+		// Now make el.paused report true so togglePlay invokes play() again.
+		definePaused(audioEl, true);
+
+		const button = container.querySelector('button.play') as HTMLButtonElement;
+		await act(async () => {
+			button.click();
+			await Promise.resolve();
+			await Promise.resolve();
+		});
+
+		expect(
+			container.querySelector('button.play')?.getAttribute('aria-label')
+		).toBe('play');
+	});
+
+	it('resumes via window focus when visibilitychange is not fired (window switch)', async () => {
+		mockAudio();
+
+		render(<WaveformNavigator audio="/test.mp3" responsive={false} />);
+
+		const audioEl = await waitForAudio();
+		const playSpy = spyOnPlay(audioEl);
+
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('play'));
+		});
+
+		// Simulate switching to another window: blur only, no visibilitychange.
+		await act(async () => {
+			window.dispatchEvent(new Event('blur'));
+		});
+
+		// Browser paused the audio while the window was in the background.
+		definePaused(audioEl, true);
+		await act(async () => {
+			audioEl.dispatchEvent(new Event('pause'));
+		});
+
+		// Return to window — only focus fires.
+		await act(async () => {
+			window.dispatchEvent(new Event('focus'));
+		});
+
+		expect(playSpy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -143,6 +143,10 @@ export function useAudioPlayer({
 	const savedTimeBeforeHiddenRef = useRef(0);
 	// Prevents overlapping resume attempts from rapid visibility/focus toggles.
 	const resumeInFlightRef = useRef(false);
+	// AbortController for the active resume attempt. Aborted on source change
+	// and on unmount so an in-flight reload can't outlive the component or
+	// stomp a freshly loaded track.
+	const resumeAbortRef = useRef<AbortController | null>(null);
 	// Tracks whether the window is currently blurred. The pause handler uses
 	// this (in addition to document.hidden) to decide whether a pause was
 	// user-initiated or browser-initiated.
@@ -247,11 +251,16 @@ export function useAudioPlayer({
 			}
 		};
 		// Fired when the media resource is reset (browser may evict the
-		// decoded buffer after long background eviction). Sync UI honestly.
+		// decoded buffer after long background eviction). Per spec the playhead
+		// is at 0 once emptied fires, so sync the displayed position too.
 		const onEmptiedEvent = () => {
 			setIsPlaying(false);
 			setIsLoading(false);
 			onLoadingChangeRef.current?.(false);
+			setCurrentTime(0);
+			if (!isControlledRef.current) {
+				onCurrentTimeChangeRef.current?.(0);
+			}
 		};
 
 		el.addEventListener('play', onPlayEvent);
@@ -305,15 +314,25 @@ export function useAudioPlayer({
 				setCurrentTime(el.currentTime);
 			}
 			setIsLoading(false);
+			onLoadingChangeRef.current?.(false);
 		};
 
-		const waitForCanPlay = (el: HTMLAudioElement, src: string) =>
+		const waitForCanPlay = (
+			el: HTMLAudioElement,
+			src: string,
+			signal: AbortSignal
+		) =>
 			new Promise<void>((resolve, reject) => {
+				if (signal.aborted) {
+					reject(new Error('aborted'));
+					return;
+				}
 				let timeoutId: ReturnType<typeof setTimeout> | null = null;
 				const cleanup = () => {
 					if (timeoutId !== null) clearTimeout(timeoutId);
 					el.removeEventListener('canplay', handleCanPlay);
 					el.removeEventListener('error', handleError);
+					signal.removeEventListener('abort', handleAbort);
 				};
 				const handleCanPlay = () => {
 					cleanup();
@@ -323,8 +342,13 @@ export function useAudioPlayer({
 					cleanup();
 					reject(new Error('reload error'));
 				};
+				const handleAbort = () => {
+					cleanup();
+					reject(new Error('aborted'));
+				};
 				el.addEventListener('canplay', handleCanPlay);
 				el.addEventListener('error', handleError);
+				signal.addEventListener('abort', handleAbort);
 				timeoutId = setTimeout(() => {
 					cleanup();
 					reject(new Error('reload timeout'));
@@ -339,6 +363,13 @@ export function useAudioPlayer({
 			if (!wasPlayingBeforeHiddenRef.current) return;
 			if (!el.paused || el.ended) return;
 			if (resumeInFlightRef.current) return;
+
+			// Abort any stale controller (defensive — shouldn't happen with the
+			// resumeInFlightRef guard, but keeps state tidy).
+			resumeAbortRef.current?.abort();
+			const controller = new AbortController();
+			resumeAbortRef.current = controller;
+			const { signal } = controller;
 
 			resumeInFlightRef.current = true;
 			try {
@@ -367,7 +398,9 @@ export function useAudioPlayer({
 					// to a full source reload.
 				}
 
-				// Bail if state changed during the await (user paused, audio swapped).
+				// Bail if state changed during the await (user paused, audio swapped,
+				// component unmounted).
+				if (signal.aborted) return;
 				if (!wasPlayingBeforeHiddenRef.current) return;
 				if (audioRef.current !== el) return;
 
@@ -378,12 +411,13 @@ export function useAudioPlayer({
 				}
 
 				try {
-					await waitForCanPlay(el, src);
+					await waitForCanPlay(el, src, signal);
 				} catch {
-					syncFromElement();
+					if (!signal.aborted) syncFromElement();
 					return;
 				}
 
+				if (signal.aborted) return;
 				if (!wasPlayingBeforeHiddenRef.current) return;
 				if (audioRef.current !== el) return;
 
@@ -402,10 +436,13 @@ export function useAudioPlayer({
 					await el.play();
 				} catch {
 					// Give up — surface honest paused state so the user can click play.
-					syncFromElement();
+					if (!signal.aborted) syncFromElement();
 				}
 			} finally {
 				resumeInFlightRef.current = false;
+				if (resumeAbortRef.current === controller) {
+					resumeAbortRef.current = null;
+				}
 			}
 		};
 
@@ -461,6 +498,10 @@ export function useAudioPlayer({
 			window.removeEventListener('pageshow', handlePageShow);
 			window.removeEventListener('blur', handleBlur);
 			window.removeEventListener('focus', handleFocus);
+			// Cancel any in-flight resume so its async tail can't fire state
+			// setters after unmount.
+			resumeAbortRef.current?.abort();
+			resumeAbortRef.current = null;
 		};
 	}, []);
 
@@ -497,8 +538,12 @@ export function useAudioPlayer({
 		}
 		const el = audioRef.current;
 
-		// New source — drop any pending resume intent so a stale saved position
-		// doesn't get applied to the next track.
+		// New source — abort any in-flight resume from the previous track so it
+		// can't stomp the new src or keep resumeInFlightRef pinned, and drop the
+		// saved resume intent so a stale position doesn't get applied.
+		resumeAbortRef.current?.abort();
+		resumeAbortRef.current = null;
+		resumeInFlightRef.current = false;
 		wasPlayingBeforeHiddenRef.current = false;
 		savedTimeBeforeHiddenRef.current = 0;
 

--- a/src/hooks/useAudioPlayer.ts
+++ b/src/hooks/useAudioPlayer.ts
@@ -1,15 +1,14 @@
 import { useEffect, useRef, useState } from 'react';
 
-// Threshold for controlled time sync to avoid feedback loops (in seconds)
+// Threshold for controlled time sync to avoid feedback loops (in seconds).
 const CONTROLLED_TIME_THRESHOLD = 0.01;
 
-// Background-tab stall recovery constants
-/** Wall-clock ms without a timeupdate event before we consider playback stalled */
-const STALL_THRESHOLD_MS = 3000;
-/** Maximum number of escalating recovery attempts per visibility-return cycle */
-const MAX_RECOVERY_ATTEMPTS = 3;
-/** Delay between escalated recovery attempts (ms) */
-const RECOVERY_ESCALATION_MS = 1500;
+// Tolerance for treating element.currentTime as "reset" relative to a saved
+// position. Browsers don't always reset to exactly 0 after media eviction.
+const POSITION_RESET_TOLERANCE = 0.5;
+
+// Maximum time to wait for canplay after reloading the source during recovery.
+const CANPLAY_TIMEOUT_MS = 8000;
 
 interface UseAudioPlayerProps {
 	audio: string | File | null | undefined;
@@ -108,6 +107,9 @@ export function useAudioPlayer({
 	const onLoadingChangeRef = useRef(onLoadingChange);
 	const onErrorRef = useRef(onError);
 
+	// Mirror isPlaying as a ref so non-React callbacks (visibility, focus, etc.)
+	// can read the latest value without restarting their effect.
+	const isPlayingRef = useRef(false);
 	useEffect(() => {
 		isPlayingRef.current = isPlaying;
 	}, [isPlaying]);
@@ -132,16 +134,19 @@ export function useAudioPlayer({
 		onError,
 	]);
 
-	// Track playback state across visibility changes / bfcache restores
-	const isPlayingRef = useRef(false);
+	// Tracks playback intent across hide/show cycles. Set when the page hides
+	// or window blurs while playing; cleared when the user pauses while the page
+	// is visible AND the window is focused, on error, on ended, and when the
+	// audio source changes. Pauses while hidden or blurred are treated as
+	// browser-initiated and preserve the intent.
 	const wasPlayingBeforeHiddenRef = useRef(false);
 	const savedTimeBeforeHiddenRef = useRef(0);
-	// Wall-clock timestamp of the last timeupdate event — used to detect stalls
-	const lastTimeupdateWallClockRef = useRef<number>(0);
-	// Number of recovery attempts in the current visibility-return cycle
-	const recoveryAttemptsRef = useRef<number>(0);
-	// Pending escalation timeout handle
-	const recoveryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Prevents overlapping resume attempts from rapid visibility/focus toggles.
+	const resumeInFlightRef = useRef(false);
+	// Tracks whether the window is currently blurred. The pause handler uses
+	// this (in addition to document.hidden) to decide whether a pause was
+	// user-initiated or browser-initiated.
+	const isWindowBlurredRef = useRef(false);
 
 	// Determine if component is in controlled mode
 	const isControlled = controlledCurrentTime !== undefined;
@@ -170,8 +175,6 @@ export function useAudioPlayer({
 		const onPlayingEvent = () => {
 			setIsLoading(false);
 			onLoadingChangeRef.current?.(false);
-			// Successful playback resume — reset recovery state
-			recoveryAttemptsRef.current = 0;
 		};
 		const onWaitingEvent = () => {
 			setIsLoading(true);
@@ -181,26 +184,19 @@ export function useAudioPlayer({
 			setIsPlaying(false);
 			setIsLoading(false);
 			onLoadingChangeRef.current?.(false);
-			// User paused playback while visible — abort any in-flight recovery.
-			// If hidden, this pause may come from browser background policy and
-			// should not clear the saved pre-hide playing state.
-			if (!document.hidden) {
+			// A pause is treated as user-initiated only when the page is visible
+			// AND the window is focused. Pauses while hidden or blurred are
+			// browser-initiated background-policy enforcement, and must preserve
+			// the resume intent so the visibility/focus handler can recover.
+			if (!document.hidden && !isWindowBlurredRef.current) {
 				wasPlayingBeforeHiddenRef.current = false;
-				recoveryAttemptsRef.current = 0;
-				if (recoveryTimerRef.current) {
-					clearTimeout(recoveryTimerRef.current);
-					recoveryTimerRef.current = null;
-				}
 			}
 			onPauseRef.current?.();
 		};
 		const onTimeEvent = () => {
 			const time = el.currentTime;
-			lastTimeupdateWallClockRef.current = Date.now();
 			setCurrentTime(time);
 			onTimeUpdateRef.current?.(time);
-
-			// Call onCurrentTimeChange for uncontrolled mode
 			if (!isControlledRef.current) {
 				onCurrentTimeChangeRef.current?.(time);
 			}
@@ -214,33 +210,32 @@ export function useAudioPlayer({
 			setIsPlaying(false);
 			setIsLoading(false);
 			onLoadingChangeRef.current?.(false);
-			// Track ended as a terminal state regardless of visibility so
-			// background recovery does not restart playback after completion.
 			wasPlayingBeforeHiddenRef.current = false;
-			recoveryAttemptsRef.current = 0;
-			if (recoveryTimerRef.current) {
-				clearTimeout(recoveryTimerRef.current);
-				recoveryTimerRef.current = null;
-			}
 			onEndedRef.current?.();
 		};
 		const onErrorEvent = () => {
+			// An error can fire after `play` without a corresponding `pause` event,
+			// leaving the UI stuck on a paused element. Reset state explicitly.
+			setIsPlaying(false);
 			setIsLoading(false);
 			onLoadingChangeRef.current?.(false);
+			wasPlayingBeforeHiddenRef.current = false;
 			const error = el.error;
 			if (error) {
+				// Use numeric MediaError codes directly; the MediaError constructor
+				// isn't exposed in every JS environment (e.g. jsdom).
 				let errorMessage: string;
 				switch (error.code) {
-					case MediaError.MEDIA_ERR_ABORTED:
+					case 1: // MEDIA_ERR_ABORTED
 						errorMessage = 'Audio loading was aborted';
 						break;
-					case MediaError.MEDIA_ERR_NETWORK:
+					case 2: // MEDIA_ERR_NETWORK
 						errorMessage = 'Network error while loading audio';
 						break;
-					case MediaError.MEDIA_ERR_DECODE:
+					case 3: // MEDIA_ERR_DECODE
 						errorMessage = 'Audio decoding failed';
 						break;
-					case MediaError.MEDIA_ERR_SRC_NOT_SUPPORTED:
+					case 4: // MEDIA_ERR_SRC_NOT_SUPPORTED
 						errorMessage =
 							'Audio source is not supported. Check that the file format is supported by this browser and that the server allows cross-origin (CORS) access for this URL.';
 						break;
@@ -251,6 +246,13 @@ export function useAudioPlayer({
 				onErrorRef.current?.(new Error(errorMessage));
 			}
 		};
+		// Fired when the media resource is reset (browser may evict the
+		// decoded buffer after long background eviction). Sync UI honestly.
+		const onEmptiedEvent = () => {
+			setIsPlaying(false);
+			setIsLoading(false);
+			onLoadingChangeRef.current?.(false);
+		};
 
 		el.addEventListener('play', onPlayEvent);
 		el.addEventListener('playing', onPlayingEvent);
@@ -260,6 +262,7 @@ export function useAudioPlayer({
 		el.addEventListener('loadedmetadata', onLoadedEvent);
 		el.addEventListener('ended', onEndedEvent);
 		el.addEventListener('error', onErrorEvent);
+		el.addEventListener('emptied', onEmptiedEvent);
 
 		return () => {
 			el.pause();
@@ -271,6 +274,7 @@ export function useAudioPlayer({
 			el.removeEventListener('loadedmetadata', onLoadedEvent);
 			el.removeEventListener('ended', onEndedEvent);
 			el.removeEventListener('error', onErrorEvent);
+			el.removeEventListener('emptied', onEmptiedEvent);
 			if (objectUrlRef.current) {
 				URL.revokeObjectURL(objectUrlRef.current);
 			}
@@ -282,174 +286,181 @@ export function useAudioPlayer({
 		// audioElementRef is intentionally excluded from deps to avoid recreating audio element
 	}, []);
 
-	// Resume audio after the browser interrupts it (Safari background-tab pause,
-	// mobile screen lock, bfcache restore). Saves playing state on hide and
-	// re-calls play() when the page/tab becomes visible again.
-	// Extends to stalled-not-paused recovery with bounded escalating retries.
+	// Visibility / bfcache / window-focus reconciliation.
+	//
+	// Strategy: treat the audio element as the source of truth. On every
+	// return-to-foreground signal, copy element state into React state, then
+	// — if the user wanted playback to continue — make a single resume attempt
+	// with a reload fallback. No timers, no escalating retries: the play()
+	// promise tells us whether it worked.
 	useEffect(() => {
-		/**
-		 * Returns true if the audio element appears stalled or paused and needs
-		 * recovery. Three signals are checked:
-		 *   1. el.paused — browser explicitly paused (e.g. Safari background policy)
-		 *   2. readyState < HAVE_FUTURE_DATA — not enough buffered data to play
-		 *   3. No timeupdate event in the last STALL_THRESHOLD_MS while not ended
-		 *      — covers silent network stalls that don't fire an error or pause event
-		 */
-		const isStalled = (el: HTMLAudioElement): boolean => {
-			if (el.paused) return true;
-			if (el.readyState < HTMLMediaElement.HAVE_FUTURE_DATA) return true;
-			if (
-				lastTimeupdateWallClockRef.current > 0 &&
-				!el.ended &&
-				Date.now() - lastTimeupdateWallClockRef.current > STALL_THRESHOLD_MS
-			) {
-				return true;
+		const syncFromElement = () => {
+			const el = audioRef.current;
+			if (!el) return;
+			const elPlaying = !el.paused && !el.ended;
+			if (isPlayingRef.current !== elPlaying) {
+				setIsPlaying(elPlaying);
 			}
-			return false;
+			if (!isControlledRef.current) {
+				setCurrentTime(el.currentTime);
+			}
+			setIsLoading(false);
 		};
 
-		/**
-		 * Attempts to recover stalled playback with up to MAX_RECOVERY_ATTEMPTS
-		 * escalating steps:
-		 *   1. Restore time (if reset) → play()
-		 *   2. pause() → seek back ε → play()  (unstick demuxer)
-		 *   3. Reload src → wait for canplay → restore time → play()
-		 *
-		 * Each step schedules the next via setTimeout so we give the browser a
-		 * chance to recover on its own. Recovery is aborted if:
-		 *   - isPlayingRef goes true (recovery worked)
-		 *   - wasPlayingBeforeHiddenRef is cleared (user paused or new tab-hide)
-		 *   - MAX_RECOVERY_ATTEMPTS is reached
-		 */
-		const recoverPlayback = (el: HTMLAudioElement, savedTime: number) => {
-			if (recoveryAttemptsRef.current >= MAX_RECOVERY_ATTEMPTS) return;
-
-			recoveryAttemptsRef.current += 1;
-			const attempt = recoveryAttemptsRef.current;
-
-			const scheduleNext = () => {
-				recoveryTimerRef.current = setTimeout(() => {
-					recoveryTimerRef.current = null;
-					// Abort if user paused or the tab was hidden again.
-					// Do not gate on React `isPlaying` state — it can be stale after
-					// background interruptions. Instead, rely on the element's real state.
-					if (!wasPlayingBeforeHiddenRef.current) return;
-					const currentEl = audioRef.current;
-					if (!currentEl || !isStalled(currentEl)) return;
-					recoverPlayback(currentEl, savedTime);
-				}, RECOVERY_ESCALATION_MS);
-			};
-
-			if (attempt === 1) {
-				// Step 1: restore time if browser reset it, then try play()
-				if (el.currentTime === 0 && savedTime > 0) {
-					el.currentTime = savedTime;
-					if (!isControlledRef.current) {
-						setCurrentTime(savedTime);
-					}
-				}
-				el.play().catch(() => {});
-				scheduleNext();
-			} else if (attempt === 2) {
-				// Step 2: force a seek to unstick the demuxer, then play()
-				const target = Math.max(0, savedTime - 0.1);
-				el.pause();
-				el.currentTime = target;
-				el.play().catch(() => {});
-				scheduleNext();
-			} else {
-				// Step 3: reload the source, restore position after canplay, then play()
-				const src = el.currentSrc || el.src;
-				if (!src) return;
-
-				const onCanPlay = () => {
-					el.removeEventListener('canplay', onCanPlay);
-					if (!wasPlayingBeforeHiddenRef.current) return;
-					el.currentTime = savedTime;
-					if (!isControlledRef.current) {
-						setCurrentTime(savedTime);
-					}
-					el.play().catch(() => {});
+		const waitForCanPlay = (el: HTMLAudioElement, src: string) =>
+			new Promise<void>((resolve, reject) => {
+				let timeoutId: ReturnType<typeof setTimeout> | null = null;
+				const cleanup = () => {
+					if (timeoutId !== null) clearTimeout(timeoutId);
+					el.removeEventListener('canplay', handleCanPlay);
+					el.removeEventListener('error', handleError);
 				};
-				el.addEventListener('canplay', onCanPlay);
+				const handleCanPlay = () => {
+					cleanup();
+					resolve();
+				};
+				const handleError = () => {
+					cleanup();
+					reject(new Error('reload error'));
+				};
+				el.addEventListener('canplay', handleCanPlay);
+				el.addEventListener('error', handleError);
+				timeoutId = setTimeout(() => {
+					cleanup();
+					reject(new Error('reload timeout'));
+				}, CANPLAY_TIMEOUT_MS);
 				el.src = src;
 				el.load();
+			});
+
+		const resumeIfNeeded = async () => {
+			const el = audioRef.current;
+			if (!el) return;
+			if (!wasPlayingBeforeHiddenRef.current) return;
+			if (!el.paused || el.ended) return;
+			if (resumeInFlightRef.current) return;
+
+			resumeInFlightRef.current = true;
+			try {
+				const saved = savedTimeBeforeHiddenRef.current;
+
+				// Restore position if the browser dropped it — within a tolerance,
+				// not just exact-zero, since some browsers reset to a small non-zero
+				// value during eviction recovery.
+				if (saved > 0 && el.currentTime < saved - POSITION_RESET_TOLERANCE) {
+					try {
+						el.currentTime = saved;
+						if (!isControlledRef.current) {
+							setCurrentTime(saved);
+						}
+					} catch {
+						// currentTime can throw if the element has no media data yet;
+						// the reload path below will restore it after canplay.
+					}
+				}
+
+				try {
+					await el.play();
+					return;
+				} catch {
+					// play() rejected — the media may have been released. Fall through
+					// to a full source reload.
+				}
+
+				// Bail if state changed during the await (user paused, audio swapped).
+				if (!wasPlayingBeforeHiddenRef.current) return;
+				if (audioRef.current !== el) return;
+
+				const src = el.currentSrc || el.src;
+				if (!src) {
+					syncFromElement();
+					return;
+				}
+
+				try {
+					await waitForCanPlay(el, src);
+				} catch {
+					syncFromElement();
+					return;
+				}
+
+				if (!wasPlayingBeforeHiddenRef.current) return;
+				if (audioRef.current !== el) return;
+
+				if (saved > 0) {
+					try {
+						el.currentTime = saved;
+						if (!isControlledRef.current) {
+							setCurrentTime(saved);
+						}
+					} catch {
+						// fall through — best effort
+					}
+				}
+
+				try {
+					await el.play();
+				} catch {
+					// Give up — surface honest paused state so the user can click play.
+					syncFromElement();
+				}
+			} finally {
+				resumeInFlightRef.current = false;
 			}
+		};
+
+		const captureHiddenState = () => {
+			const el = audioRef.current;
+			if (!el) return;
+			wasPlayingBeforeHiddenRef.current = isPlayingRef.current;
+			savedTimeBeforeHiddenRef.current = el.currentTime;
 		};
 
 		const handleVisibilityChange = () => {
-			const el = audioRef.current;
-			if (!el) return;
-
 			if (document.hidden) {
-				// Save state before hide; clear any in-progress recovery
-				wasPlayingBeforeHiddenRef.current = isPlayingRef.current;
-				savedTimeBeforeHiddenRef.current = el.currentTime;
-				// Browsers may throttle/suppress `timeupdate` while hidden.
-				// Reset the wall clock baseline so hidden time isn't treated as a stall.
-				lastTimeupdateWallClockRef.current = Date.now();
-				if (recoveryTimerRef.current) {
-					clearTimeout(recoveryTimerRef.current);
-					recoveryTimerRef.current = null;
-				}
-				recoveryAttemptsRef.current = 0;
-			} else if (wasPlayingBeforeHiddenRef.current) {
-				// Reconcile UI state with the element on return: browsers can pause or
-				// reset media while hidden without delivering events in a timely order.
-				// This keeps the play/pause button from getting stuck showing "pause"
-				// while the element is actually paused.
-				const shouldBePlaying = !el.paused && !el.ended;
-				if (isPlayingRef.current !== shouldBePlaying) {
-					setIsPlaying(shouldBePlaying);
-				}
-
-				const progressedWhileHidden =
-					el.currentTime >
-					savedTimeBeforeHiddenRef.current + CONTROLLED_TIME_THRESHOLD;
-				// If the media clearly advanced while hidden and is not stalled on return,
-				// don't force recovery — desktop browsers often suppress timeupdate in
-				// background tabs even though playback is healthy.
-				// Important: check this before applying the wall-clock stall heuristic,
-				// otherwise long hidden intervals can look like a stall even when media
-				// advanced normally.
-				if (
-					progressedWhileHidden &&
-					!el.paused &&
-					el.readyState >= HTMLMediaElement.HAVE_FUTURE_DATA
-				) {
-					lastTimeupdateWallClockRef.current = Date.now();
-					recoveryAttemptsRef.current = 0;
-					return;
-				}
-				const stalled = isStalled(el);
-				if (stalled) {
-					recoverPlayback(el, savedTimeBeforeHiddenRef.current);
-				}
+				captureHiddenState();
+			} else {
+				syncFromElement();
+				resumeIfNeeded();
 			}
 		};
 
-		// pageshow fires with persisted=true when the page is restored from bfcache
-		// (common on mobile Safari). visibilitychange may not fire in that path.
+		// pageshow with persisted=true means a bfcache restore (Safari/mobile).
+		// For non-bfcache pageshows we still sync the UI but don't auto-resume —
+		// the visibilitychange handler covers normal navigation returns.
 		const handlePageShow = (event: PageTransitionEvent) => {
-			if (!event.persisted) return;
-			const el = audioRef.current;
-			if (!el) return;
-
-			if (wasPlayingBeforeHiddenRef.current && isStalled(el)) {
-				recoverPlayback(el, savedTimeBeforeHiddenRef.current);
+			syncFromElement();
+			if (event.persisted) {
+				resumeIfNeeded();
 			}
+		};
+
+		// Some platforms (Safari macOS when switching windows, not tabs) deliver
+		// blur/focus without firing visibilitychange. Mirror the same logic so
+		// background-paused audio still recovers on window return.
+		const handleBlur = () => {
+			isWindowBlurredRef.current = true;
+			if (isPlayingRef.current) {
+				captureHiddenState();
+			}
+		};
+		const handleFocus = () => {
+			isWindowBlurredRef.current = false;
+			if (document.hidden) return;
+			syncFromElement();
+			resumeIfNeeded();
 		};
 
 		document.addEventListener('visibilitychange', handleVisibilityChange);
 		window.addEventListener('pageshow', handlePageShow);
+		window.addEventListener('blur', handleBlur);
+		window.addEventListener('focus', handleFocus);
 
 		return () => {
 			document.removeEventListener('visibilitychange', handleVisibilityChange);
 			window.removeEventListener('pageshow', handlePageShow);
-			if (recoveryTimerRef.current) {
-				clearTimeout(recoveryTimerRef.current);
-				recoveryTimerRef.current = null;
-			}
+			window.removeEventListener('blur', handleBlur);
+			window.removeEventListener('focus', handleFocus);
 		};
 	}, []);
 
@@ -486,13 +497,10 @@ export function useAudioPlayer({
 		}
 		const el = audioRef.current;
 
-		// New source — reset recovery state so a fresh recovery cycle can start
-		recoveryAttemptsRef.current = 0;
+		// New source — drop any pending resume intent so a stale saved position
+		// doesn't get applied to the next track.
 		wasPlayingBeforeHiddenRef.current = false;
-		if (recoveryTimerRef.current) {
-			clearTimeout(recoveryTimerRef.current);
-			recoveryTimerRef.current = null;
-		}
+		savedTimeBeforeHiddenRef.current = 0;
 
 		// Cleanup previous
 		if (objectUrlRef.current) {
@@ -549,7 +557,11 @@ export function useAudioPlayer({
 		}
 		if (a.paused) {
 			a.preload = 'auto';
-			a.play();
+			// A rejected play() promise can otherwise leave UI thinking the
+			// element is playing when it isn't.
+			a.play().catch(() => {
+				setIsPlaying(false);
+			});
 		} else {
 			a.pause();
 		}


### PR DESCRIPTION
Fixes the long-standing bug where switching to another tab/window and returning after a while caused playback to stop and `currentTime` to reset to 0 while the play/pause button stayed showing "pause" — i.e. React state out of sync with the audio element.

## Root cause

The prior recovery scheme tried to predict what the browser did while the page was hidden and run a matching `setTimeout`-escalated recovery. Real browser behaviour didn't fit the model:

- `error` and (uncaught) `emptied` events could fire after `play` with no preceding `pause`, leaving the play button stuck on "pause" while the element was actually paused at 0.
- Reconciliation was gated on `wasPlayingBeforeHiddenRef`, which a late browser-issued `pause` could clear before the visibility handler saw it, suppressing the sync entirely.
- `play()` rejection was swallowed by `.catch(() => {})`, so the UI couldn't tell the resume had failed and waited 1.5s+ for the next `setTimeout` escalation (which is throttled in freshly-foregrounded tabs).
- Position restore only fired when `currentTime === 0` exactly; some browsers reset to a small non-zero value during eviction.

## Approach

Treat the audio element as the source of truth instead of predicting. On every return-to-foreground signal (`visibilitychange`, `pageshow` with `persisted`, `focus`), copy element state into React state, then — if the user wanted playback to continue — make one awaited resume attempt with a single source-reload fallback. The `play()` promise tells us whether it worked; honest paused UI is shown if both attempts fail.

## What changed in `src/hooks/useAudioPlayer.ts`

- **`syncFromElement()`** copies `el.paused`/`el.currentTime` into React on every visibility/focus/pageshow return; gates `setIsPlaying` on diff; emits `onLoadingChange(false)`.
- **Single awaited `resumeIfNeeded()`** with reload fallback replaces the 3-step escalation, `recoveryAttemptsRef`, `recoveryTimerRef`, and stall-detection heuristics. Uses `AbortController` so source changes / unmount cancel any in-flight reload.
- **`error` and `emptied` handlers** reset `isPlaying` (and `currentTime` on `emptied`) so a media failure can't leave the button stuck.
- **`togglePlay`** catches `play()` rejection so NotAllowed/Abort errors don't leave the button reading "pause".
- **Position restore uses a 0.5 s tolerance**, not exact-0.
- **`blur`/`focus` listeners** cover platforms where switching windows fires only those, not `visibilitychange`. A new `isWindowBlurredRef` keeps the pause handler from clearing the resume intent on browser-initiated background pauses.
- ~130 lines of escalating-recovery machinery removed.

## Tests

`src/__tests__/WaveformNavigator.visibility.test.tsx` rewritten: 4 obsolete tests dropped (escalation cap, scheduled-retry cancel, stalled-but-not-paused, escalation-when-stuck) and 11 new ones added — UI reconciliation, non-zero position restore, error/emptied resets, togglePlay rejection, reload-on-play-rejection, paused-UI-after-double-failure, focus-only recovery, abort-on-source-change, `onLoadingChange` sync, emptied resets currentTime.

## Test plan

- [x] `npm test` — 129/129 passing
- [x] `npm run type-check` — clean
- [x] `npm run build` — clean
- [ ] Manual: play audio, switch to another tab, leave for 10+ minutes, return — playback resumes from saved position or shows honest paused state
- [ ] Manual: same but switch to another window (not tab) — focus/blur path
- [ ] Manual: same on Safari macOS / mobile Safari (bfcache path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)