### PR TITLE
feat/interactive waveform markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,15 +185,24 @@ The `styles` prop accepts an object with the following optional properties:
 The component supports displaying markers at specific time positions on the waveform. Markers can be used to indicate important moments, chapters, or annotations in the audio.
 
 - **`markers`** (Marker[] | undefined): Array of marker objects to display on the waveform. Each marker specifies a time position and optionally custom rendering.
+- **`onMarkerClick`** ((marker, index, event) => void | undefined): Fires when a marker's hit region is clicked or tapped. Supplying this (or `onMarkerHover`) enables marker hit-testing; when a click hits a marker, the default click-to-seek is suppressed so your handler decides what happens.
+- **`onMarkerHover`** ((marker | null, index | null) => void | undefined): Fires when the hovered marker changes — with `(marker, index)` on enter/change and `(null, null)` when the pointer leaves all markers.
+- **`markerHitRadius`** (number, default: `12`): Half-width in CSS pixels of the default full-height hit column around each marker.
 
 **Marker Interface:**
 
 ```tsx
-import type { Marker, MarkerRenderProps } from 'waveform-navigator';
+import type {
+  Marker,
+  MarkerRenderProps,
+  MarkerHitTestArgs,
+} from 'waveform-navigator';
 
 interface Marker {
   time: number; // Time position in seconds where the marker should be displayed
+  id?: string; // Optional stable identity echoed back in onMarkerClick/onMarkerHover
   markup?: (props: MarkerRenderProps) => void; // Optional custom rendering function
+  hitTest?: (args: MarkerHitTestArgs) => boolean; // Optional custom hit region
 }
 
 interface MarkerRenderProps {
@@ -202,6 +211,15 @@ interface MarkerRenderProps {
   height: number; // Height of the waveform canvas in pixels
   index: number; // Index of the marker in the markers array
   marker: Marker; // The marker object
+  hovered?: boolean; // True while the pointer is over this marker's hit region
+}
+
+interface MarkerHitTestArgs {
+  x: number; // Pointer x in canvas bounding-rect (CSS px) coordinates
+  y: number; // Pointer y in canvas bounding-rect (CSS px) coordinates
+  markerX: number; // (marker.time / duration) * width
+  width: number; // Canvas bounding-rect width
+  height: number; // Canvas bounding-rect height
 }
 ```
 
@@ -270,12 +288,43 @@ Use the `styles` prop to customize the default marker colors:
 />
 ```
 
+**Interactive Markers (click & hover):**
+
+Provide `onMarkerClick` and/or `onMarkerHover` to make markers individually clickable and hoverable — for example, to render speech-bubble comment markers and know exactly which comment was clicked:
+
+```tsx
+const commentMarker = ({ ctx, x, height, hovered, marker }: MarkerRenderProps) => {
+  ctx.fillStyle = hovered ? '#1d4ed8' : '#2b6ef6';
+  ctx.beginPath();
+  ctx.arc(x, 16, hovered ? 10 : 8, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.fillRect(x - 1, 16, 2, height - 16);
+};
+
+const comments = [
+  { time: 12, id: 'comment-1' },
+  { time: 48, id: 'comment-2' },
+];
+
+<WaveformNavigator
+  audio="/audio.mp3"
+  markers={comments.map((c) => ({ time: c.time, id: c.id, markup: commentMarker }))}
+  onMarkerClick={(marker) => openComment(marker.id)}
+  onMarkerHover={(marker) => setHoveredCommentId(marker?.id ?? null)}
+/>
+```
+
+When neither `onMarkerClick` nor `onMarkerHover` is supplied, markers remain purely decorative and clicking anywhere on the waveform always seeks — the same behavior as before these props existed.
+
 **Notes:**
 
 - Markers are positioned based on their `time` value relative to the audio duration.
 - Markers outside the valid time range (time < 0 or time > duration) will not be rendered.
 - The marker index (shown in default labels as M1, M2, etc.) corresponds to the marker's position in the array, starting from 1.
 - Custom markup functions receive the canvas context and should handle all drawing operations.
+- The default hit region for a marker is a full-height column `markerHitRadius` px wide on either side of its x position; override it per-marker with `hitTest`.
+- When multiple markers' hit regions overlap, the nearest one to the pointer wins; ties resolve to the lowest array index.
+- On touch devices, tapping a marker fires `onMarkerClick` without seeking; dragging away from the initial touch point falls back to the normal scrub-seek behavior.
 
 #### Controlled Props
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ The component supports displaying markers at specific time positions on the wave
 - **`markers`** (Marker[] | undefined): Array of marker objects to display on the waveform. Each marker specifies a time position and optionally custom rendering.
 - **`onMarkerClick`** ((marker, index, event) => void | undefined): Fires when a marker's hit region is clicked or tapped. Supplying this (or `onMarkerHover`) enables marker hit-testing; when a click hits a marker, the default click-to-seek is suppressed so your handler decides what happens.
 - **`onMarkerHover`** ((marker | null, index | null) => void | undefined): Fires when the hovered marker changes — with `(marker, index)` on enter/change and `(null, null)` when the pointer leaves all markers.
-- **`markerHitRadius`** (number, default: `12`): Half-width in CSS pixels of the default full-height hit column around each marker.
+- **`markerHitRadius`** (number, default: `2`): Extra padding in CSS pixels around the default M1/M2/… label badge hit region. The stem below the label is not part of the default hit target.
 
 **Marker Interface:**
 
@@ -322,7 +322,7 @@ When neither `onMarkerClick` nor `onMarkerHover` is supplied, markers remain pur
 - Markers outside the valid time range (time < 0 or time > duration) will not be rendered.
 - The marker index (shown in default labels as M1, M2, etc.) corresponds to the marker's position in the array, starting from 1.
 - Custom markup functions receive the canvas context and should handle all drawing operations.
-- The default hit region for a marker is a full-height column `markerHitRadius` px wide on either side of its x position; override it per-marker with `hitTest`.
+- The default hit region for a marker is the M1/M2/… label badge (plus `markerHitRadius` padding), not the full-height stem — so clicks on the waveform near markers can still seek. Override the region per-marker with `hitTest`.
 - When multiple markers' hit regions overlap, the nearest one to the pointer wins; ties resolve to the lowest array index.
 - On touch devices, tapping a marker fires `onMarkerClick` without seeking; dragging away from the initial touch point falls back to the normal scrub-seek behavior.
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import BasicTab from './tabs/BasicTab';
 import StylesTab from './tabs/StylesTab';
 import MarkersTab from './tabs/MarkersTab';
+import InteractiveMarkersTab from './tabs/InteractiveMarkersTab';
 import ControlledTab from './tabs/ControlledTab';
 import ResponsiveTab from './tabs/ResponsiveTab';
 import AdvancedTab from './tabs/AdvancedTab';
@@ -11,6 +12,7 @@ type TabId =
 	| 'basic'
 	| 'styles'
 	| 'markers'
+	| 'interactivemarkers'
 	| 'controlled'
 	| 'responsive'
 	| 'advanced'
@@ -20,6 +22,7 @@ const TABS: { id: TabId; label: string }[] = [
 	{ id: 'basic', label: 'Basic' },
 	{ id: 'styles', label: 'Styles' },
 	{ id: 'markers', label: 'Markers' },
+	{ id: 'interactivemarkers', label: 'Interactive Markers' },
 	{ id: 'controlled', label: 'Controlled' },
 	{ id: 'responsive', label: 'Responsive' },
 	{ id: 'advanced', label: 'Advanced' },
@@ -86,6 +89,7 @@ export default function App() {
 				{activeTab === 'basic' && <BasicTab />}
 				{activeTab === 'styles' && <StylesTab />}
 				{activeTab === 'markers' && <MarkersTab />}
+				{activeTab === 'interactivemarkers' && <InteractiveMarkersTab />}
 				{activeTab === 'controlled' && <ControlledTab />}
 				{activeTab === 'responsive' && <ResponsiveTab />}
 				{activeTab === 'advanced' && <AdvancedTab />}

--- a/demo/src/tabs/InteractiveMarkersTab.tsx
+++ b/demo/src/tabs/InteractiveMarkersTab.tsx
@@ -1,0 +1,272 @@
+import React, { useState } from 'react';
+import WaveformNavigator from '../../../src';
+import type { Marker, MarkerRenderProps } from '../../../src';
+
+const DEMO_AUDIO_PATH = `${import.meta.env.BASE_URL}media/Demo.mp3`;
+
+const commentMarkerMarkup = ({
+	ctx,
+	x,
+	height,
+	hovered,
+}: MarkerRenderProps) => {
+	const radius = hovered ? 10 : 8;
+	ctx.fillStyle = hovered ? '#1d4ed8' : '#2b6ef6';
+	ctx.beginPath();
+	ctx.arc(x, 16, radius, 0, Math.PI * 2);
+	ctx.fill();
+
+	// Tail pointing down toward the waveform
+	ctx.beginPath();
+	ctx.moveTo(x - 4, 22);
+	ctx.lineTo(x + 4, 22);
+	ctx.lineTo(x, 28);
+	ctx.closePath();
+	ctx.fill();
+
+	ctx.fillStyle = hovered ? '#1d4ed8' : '#93c5fd';
+	ctx.fillRect(x - 1, 28, 2, height - 28);
+};
+
+/** Hit the bubble near the top, or a narrow column down the stem. */
+const commentHitTest: NonNullable<Marker['hitTest']> = ({
+	x,
+	y,
+	markerX,
+}) => {
+	const dx = x - markerX;
+	const dy = y - 16;
+	return Math.sqrt(dx * dx + dy * dy) <= 14 || Math.abs(dx) <= 6;
+};
+
+type EventLog = { label: string; detail: string };
+
+export default function InteractiveMarkersTab() {
+	const [duration, setDuration] = useState(0);
+	const [defaultLog, setDefaultLog] = useState<EventLog | null>(null);
+	const [defaultHover, setDefaultHover] = useState<string | null>(null);
+	const [customLog, setCustomLog] = useState<EventLog | null>(null);
+	const [hoveredCommentId, setHoveredCommentId] = useState<string | null>(null);
+	const [selectedCommentId, setSelectedCommentId] = useState<string | null>(
+		null
+	);
+
+	const defaultMarkers: Marker[] =
+		duration === 0
+			? []
+			: [
+					{ time: duration * 0.2, id: 'default-1' },
+					{ time: duration * 0.5, id: 'default-2' },
+					{ time: duration * 0.8, id: 'default-3' },
+				];
+
+	const customMarkers: Marker[] =
+		duration === 0
+			? []
+			: [
+					{
+						time: duration * 0.25,
+						id: 'comment-1',
+						markup: commentMarkerMarkup,
+						hitTest: commentHitTest,
+					},
+					{
+						time: duration * 0.55,
+						id: 'comment-2',
+						markup: commentMarkerMarkup,
+						hitTest: commentHitTest,
+					},
+					{
+						time: duration * 0.75,
+						id: 'comment-3',
+						markup: commentMarkerMarkup,
+						hitTest: commentHitTest,
+					},
+				];
+
+	const comments: Record<string, string> = {
+		'comment-1': 'Intro — nice opening motif',
+		'comment-2': 'Chorus hits here',
+		'comment-3': 'Bridge / breakdown',
+	};
+
+	return (
+		<div>
+			<h2>Interactive Markers</h2>
+			<p style={{ color: '#6b7280', marginBottom: 24 }}>
+				Supply <code>onMarkerClick</code> and/or <code>onMarkerHover</code> to
+				make markers individually clickable and hoverable. Without those
+				callbacks, markers stay decorative and clicks always seek. Below: default
+				hit-testing &amp; rendering, then custom markup + <code>hitTest</code>.
+			</p>
+
+			{duration === 0 && (
+				<p style={{ fontSize: 12, color: '#92400e', marginBottom: 12 }}>
+					⏳ Waiting for audio to load — markers appear once duration is known.
+				</p>
+			)}
+
+			{/* Default interactive */}
+			<div className="demo-section" style={{ backgroundColor: '#f0f9ff' }}>
+				<h3 style={{ marginTop: 0 }}>Default behaviour</h3>
+				<p style={{ fontSize: 13, color: '#374151', marginBottom: 12 }}>
+					Built-in M1 / M2 / M3 markers with the default label-badge hit region (
+					<code>markerHitRadius</code> padding). Only the label is interactive — the
+					stem below stays free for seeking. Click a marker to fire{' '}
+					<code>onMarkerClick</code> (seek is suppressed); hover to see{' '}
+					<code>onMarkerHover</code>. Click elsewhere on the waveform to seek as
+					usual.
+				</p>
+
+				<div
+					style={{
+						fontSize: 13,
+						marginBottom: 12,
+						minHeight: 40,
+						color: '#1e3a5f',
+					}}
+				>
+					<div>
+						<strong>Hover:</strong>{' '}
+						{defaultHover ?? (
+							<span style={{ color: '#6b7280' }}>none</span>
+						)}
+					</div>
+					<div>
+						<strong>Last click:</strong>{' '}
+						{defaultLog ? (
+							<>
+								{defaultLog.label}{' '}
+								<span style={{ color: '#6b7280' }}>({defaultLog.detail})</span>
+							</>
+						) : (
+							<span style={{ color: '#6b7280' }}>none yet</span>
+						)}
+					</div>
+				</div>
+
+				<WaveformNavigator
+					audio={DEMO_AUDIO_PATH}
+					height={120}
+					preload="metadata"
+					markers={defaultMarkers}
+					onLoaded={(dur) => setDuration(dur)}
+					onMarkerClick={(marker, index) => {
+						setDefaultLog({
+							label: marker.id ?? `M${index + 1}`,
+							detail: `${marker.time.toFixed(1)}s · index ${index}`,
+						});
+					}}
+					onMarkerHover={(marker, index) => {
+						setDefaultHover(
+							marker
+								? `${marker.id ?? `M${(index ?? 0) + 1}`} @ ${marker.time.toFixed(1)}s`
+								: null
+						);
+					}}
+					onPeaksComputed={() => {
+						(window as any).__waveformReady = true;
+					}}
+				/>
+			</div>
+
+			{/* Custom interactive */}
+			<div
+				className="demo-section"
+				style={{ backgroundColor: '#eef2ff', marginTop: 16 }}
+			>
+				<h3 style={{ marginTop: 0 }}>Custom behaviour</h3>
+				<p style={{ fontSize: 13, color: '#374151', marginBottom: 12 }}>
+					Comment-style markers with custom <code>markup</code> (uses the{' '}
+					<code>hovered</code> flag), per-marker <code>hitTest</code>, and click
+					handlers that select a comment instead of seeking.
+				</p>
+
+				<div
+					style={{
+						fontSize: 13,
+						marginBottom: 12,
+						minHeight: 56,
+						color: '#312e81',
+					}}
+				>
+					<div>
+						<strong>Hover:</strong>{' '}
+						{hoveredCommentId ? (
+							comments[hoveredCommentId]
+						) : (
+							<span style={{ color: '#6b7280' }}>none</span>
+						)}
+					</div>
+					<div>
+						<strong>Selected:</strong>{' '}
+						{selectedCommentId ? (
+							comments[selectedCommentId]
+						) : (
+							<span style={{ color: '#6b7280' }}>none yet — click a bubble</span>
+						)}
+					</div>
+					{customLog && (
+						<div style={{ color: '#6b7280', marginTop: 4 }}>
+							Last event: {customLog.label} ({customLog.detail})
+						</div>
+					)}
+				</div>
+
+				<WaveformNavigator
+					audio={DEMO_AUDIO_PATH}
+					height={120}
+					preload="metadata"
+					markers={customMarkers}
+					onLoaded={(dur) => setDuration(dur)}
+					onMarkerClick={(marker, index) => {
+						setSelectedCommentId(marker.id ?? null);
+						setCustomLog({
+							label: marker.id ?? `marker-${index}`,
+							detail: `${marker.time.toFixed(1)}s`,
+						});
+					}}
+					onMarkerHover={(marker) => {
+						setHoveredCommentId(marker?.id ?? null);
+					}}
+				/>
+			</div>
+
+			<div
+				className="demo-section"
+				style={{ marginTop: 24, backgroundColor: '#f0fdf4' }}
+			>
+				<h3 style={{ marginTop: 0 }}>Usage</h3>
+				<pre
+					style={{ margin: 0, fontSize: 13, overflowX: 'auto' }}
+				>{`// Default interactive markers
+<WaveformNavigator
+  audio="/audio.mp3"
+  markers={[{ time: 12 }, { time: 48 }]}
+  onMarkerClick={(marker, index) => console.log(marker, index)}
+  onMarkerHover={(marker) => setHovered(marker)}
+/>
+
+// Custom markup + hitTest + hovered highlight
+const commentMarker = ({ ctx, x, height, hovered }: MarkerRenderProps) => {
+  ctx.fillStyle = hovered ? '#1d4ed8' : '#2b6ef6';
+  ctx.beginPath();
+  ctx.arc(x, 16, hovered ? 10 : 8, 0, Math.PI * 2);
+  ctx.fill();
+};
+
+<WaveformNavigator
+  audio="/audio.mp3"
+  markers={comments.map((c) => ({
+    time: c.time,
+    id: c.id,
+    markup: commentMarker,
+    hitTest: ({ x, y, markerX }) => /* custom region */,
+  }))}
+  onMarkerClick={(marker) => openComment(marker.id)}
+  onMarkerHover={(marker) => setHoveredId(marker?.id ?? null)}
+/>`}</pre>
+			</div>
+		</div>
+	);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "waveform-navigator",
-	"version": "0.3.0",
+	"version": "0.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "waveform-navigator",
-			"version": "0.3.0",
+			"version": "0.5.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@axe-core/playwright": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "waveform-navigator",
-	"version": "0.3.0",
+	"version": "0.5.0",
 	"description": "A React component to display and navigate audio waveforms with custom controls.",
 	"main": "./dist/index.cjs",
 	"module": "./dist/index.mjs",

--- a/src/WaveformNavigator.tsx
+++ b/src/WaveformNavigator.tsx
@@ -613,11 +613,13 @@ const WaveformNavigator = React.forwardRef<
 					startX: touch.clientX,
 					startY: touch.clientY,
 				};
+				updateHoveredMarker(hit.index);
 				setHoverX(x);
 				const t = duration > 0 ? (x / rect.width) * duration : 0;
 				setHoverTime(isFinite(t) ? t : null);
 				return;
 			}
+			updateHoveredMarker(null);
 		}
 
 		pendingTouchMarkerRef.current = null;
@@ -651,6 +653,7 @@ const WaveformNavigator = React.forwardRef<
 			}
 			// Moved beyond slop: cancel the pending marker and fall back to scrub-seek.
 			pendingTouchMarkerRef.current = null;
+			updateHoveredMarker(null);
 		}
 
 		const x = Math.max(0, Math.min(rect.width, touch.clientX - rect.left));
@@ -669,6 +672,7 @@ const WaveformNavigator = React.forwardRef<
 		if (pending && e.type === 'touchend') {
 			onMarkerClick?.(pending.marker, pending.index, e);
 		}
+		updateHoveredMarker(null);
 		setHoverX(null);
 		setHoverTime(null);
 	}

--- a/src/WaveformNavigator.tsx
+++ b/src/WaveformNavigator.tsx
@@ -336,6 +336,7 @@ const WaveformNavigator = React.forwardRef<
 		startY: number;
 	} | null>(null);
 	const interactiveMarkers = Boolean(onMarkerClick || onMarkerHover);
+	const clickableMarkers = Boolean(onMarkerClick);
 	const [errorState, setErrorState] = useState<{
 		message: string;
 		type: 'audio' | 'waveform';
@@ -507,6 +508,9 @@ const WaveformNavigator = React.forwardRef<
 
 		markers.forEach((marker, index) => {
 			const markerX = (marker.time / duration) * rectWidth;
+			if (markerX < 0 || markerX > rectWidth) {
+				return;
+			}
 			const hit = marker.hitTest
 				? marker.hitTest({ x, y, markerX, width: rectWidth, height: rectHeight })
 				: hitTestDefaultMarkerLabel({
@@ -549,7 +553,7 @@ const WaveformNavigator = React.forwardRef<
 
 		const x = e.clientX - rect.left;
 
-		if (interactiveMarkers) {
+		if (clickableMarkers) {
 			const y = e.clientY - rect.top;
 			const hit = hitTestMarkers(x, y, rect.width, rect.height);
 			if (hit) {
@@ -603,7 +607,7 @@ const WaveformNavigator = React.forwardRef<
 
 		const x = Math.max(0, Math.min(rect.width, touch.clientX - rect.left));
 
-		if (interactiveMarkers) {
+		if (clickableMarkers) {
 			const y = touch.clientY - rect.top;
 			const hit = hitTestMarkers(x, y, rect.width, rect.height);
 			if (hit) {

--- a/src/WaveformNavigator.tsx
+++ b/src/WaveformNavigator.tsx
@@ -49,6 +49,24 @@ export interface MarkerRenderProps {
 	index: number;
 	/** The marker object */
 	marker: Marker;
+	/** True while the pointer is over this marker's hit region (interactive mode only). */
+	hovered?: boolean;
+}
+
+/**
+ * Arguments passed to a marker's custom `hitTest` function.
+ */
+export interface MarkerHitTestArgs {
+	/** Pointer position in canvas CSS-pixel (bounding-rect) coordinates. */
+	x: number;
+	/** Pointer position in canvas CSS-pixel (bounding-rect) coordinates. */
+	y: number;
+	/** The marker's x position: (marker.time / duration) * rect.width */
+	markerX: number;
+	/** Canvas bounding-rect width (CSS pixels). */
+	width: number;
+	/** Canvas bounding-rect height (CSS pixels). */
+	height: number;
 }
 
 /**
@@ -57,8 +75,12 @@ export interface MarkerRenderProps {
 export interface Marker {
 	/** Time position in seconds where the marker should be displayed */
 	time: number;
+	/** Optional stable identity echoed back in callbacks (e.g. a comment id). */
+	id?: string;
 	/** Optional custom rendering function. If not provided, uses default marker appearance. */
 	markup?: (props: MarkerRenderProps) => void;
+	/** Optional custom hit region; overrides the default hit column for this marker. */
+	hitTest?: (args: MarkerHitTestArgs) => boolean;
 }
 
 /**
@@ -115,6 +137,27 @@ export interface WaveformNavigatorProps {
 	 * Example: markers={[{ time: 10 }, { time: 20, markup: customRenderFn }]}
 	 */
 	markers?: Marker[];
+	/**
+	 * Fires when a marker's hit region is clicked/tapped.
+	 * When it fires, the default seek-to-click-position is suppressed — the host decides
+	 * what to do (it can still call the seek handle itself).
+	 * Supplying this (or `onMarkerHover`) enables marker hit-testing.
+	 */
+	onMarkerClick?: (
+		marker: Marker,
+		index: number,
+		event: React.MouseEvent | React.TouchEvent
+	) => void;
+	/**
+	 * Half-width in CSS px of the default full-height hit column around each marker.
+	 * @default 12
+	 */
+	markerHitRadius?: number;
+	/**
+	 * Fires with the hovered marker, or (null, null) when leaving all markers.
+	 * Supplying this (or `onMarkerClick`) enables marker hit-testing.
+	 */
+	onMarkerHover?: (marker: Marker | null, index: number | null) => void;
 	/**
 	 * Pre-computed peaks for instant waveform rendering without waiting for audio to load.
 	 * Accepts a `Float32Array` or plain `number[]` (e.g. from JSON-deserialized storage).
@@ -244,6 +287,9 @@ const WaveformNavigator = React.forwardRef<
 		gap = 2,
 		styles = {},
 		markers = [],
+		onMarkerClick,
+		markerHitRadius = 12,
+		onMarkerHover,
 		precomputedPeaks,
 		peakComputationWidth = 1400,
 		responsive = true,
@@ -276,6 +322,17 @@ const WaveformNavigator = React.forwardRef<
 	} = props;
 	const [hoverX, setHoverX] = useState<number | null>(null);
 	const [hoverTime, setHoverTime] = useState<number | null>(null);
+	const [hoveredMarkerIndex, setHoveredMarkerIndex] = useState<number | null>(
+		null
+	);
+	const hoveredMarkerIndexRef = useRef<number | null>(null);
+	const pendingTouchMarkerRef = useRef<{
+		marker: Marker;
+		index: number;
+		startX: number;
+		startY: number;
+	} | null>(null);
+	const interactiveMarkers = Boolean(onMarkerClick || onMarkerHover);
 	const [errorState, setErrorState] = useState<{
 		message: string;
 		type: 'audio' | 'waveform';
@@ -421,11 +478,58 @@ const WaveformNavigator = React.forwardRef<
 		markerColor,
 		markerLabelColor,
 		markers,
+		hoveredMarkerIndex,
 		peaks,
 		currentTime: displayTime,
 		duration,
 		isPlaying,
 	});
+
+	// Half-width in px within which a touch move is still considered "in place"
+	// before falling back to scrub-seek behavior.
+	const TOUCH_SLOP = 10;
+
+	function hitTestMarkers(
+		x: number,
+		y: number,
+		rectWidth: number,
+		rectHeight: number
+	): { marker: Marker; index: number } | null {
+		if (duration <= 0) {
+			return null;
+		}
+
+		let best: { marker: Marker; index: number } | null = null;
+		let bestDist = Infinity;
+
+		markers.forEach((marker, index) => {
+			const markerX = (marker.time / duration) * rectWidth;
+			const hit = marker.hitTest
+				? marker.hitTest({ x, y, markerX, width: rectWidth, height: rectHeight })
+				: Math.abs(x - markerX) <= markerHitRadius;
+
+			if (!hit) {
+				return;
+			}
+
+			const dist = Math.abs(x - markerX);
+			if (dist < bestDist) {
+				bestDist = dist;
+				best = { marker, index };
+			}
+		});
+
+		return best;
+	}
+
+	function updateHoveredMarker(index: number | null) {
+		if (hoveredMarkerIndexRef.current === index) {
+			return;
+		}
+		hoveredMarkerIndexRef.current = index;
+		setHoveredMarkerIndex(index);
+		onMarkerHover?.(index !== null ? markers[index] : null, index);
+	}
 
 	function onCanvasClick(e: React.MouseEvent<HTMLCanvasElement>) {
 		const rect = canvasRef.current?.getBoundingClientRect();
@@ -434,6 +538,16 @@ const WaveformNavigator = React.forwardRef<
 		}
 
 		const x = e.clientX - rect.left;
+
+		if (interactiveMarkers) {
+			const y = e.clientY - rect.top;
+			const hit = hitTestMarkers(x, y, rect.width, rect.height);
+			if (hit) {
+				onMarkerClick?.(hit.marker, hit.index, e);
+				return;
+			}
+		}
+
 		const t = (x / rect.width) * duration;
 		if (!Number.isNaN(t)) {
 			const newTime = Math.max(0, Math.min(duration, t));
@@ -450,11 +564,20 @@ const WaveformNavigator = React.forwardRef<
 		setHoverX(x);
 		const t = duration > 0 ? (x / rect.width) * duration : 0;
 		setHoverTime(isFinite(t) ? t : null);
+
+		if (interactiveMarkers) {
+			const y = e.clientY - rect.top;
+			const hit = hitTestMarkers(x, y, rect.width, rect.height);
+			updateHoveredMarker(hit ? hit.index : null);
+		}
 	}
 
 	function onCanvasLeave() {
 		setHoverX(null);
 		setHoverTime(null);
+		if (interactiveMarkers) {
+			updateHoveredMarker(null);
+		}
 	}
 
 	function onCanvasTouchStart(e: React.TouchEvent<HTMLCanvasElement>) {
@@ -469,6 +592,25 @@ const WaveformNavigator = React.forwardRef<
 		}
 
 		const x = Math.max(0, Math.min(rect.width, touch.clientX - rect.left));
+
+		if (interactiveMarkers) {
+			const y = touch.clientY - rect.top;
+			const hit = hitTestMarkers(x, y, rect.width, rect.height);
+			if (hit) {
+				pendingTouchMarkerRef.current = {
+					marker: hit.marker,
+					index: hit.index,
+					startX: touch.clientX,
+					startY: touch.clientY,
+				};
+				setHoverX(x);
+				const t = duration > 0 ? (x / rect.width) * duration : 0;
+				setHoverTime(isFinite(t) ? t : null);
+				return;
+			}
+		}
+
+		pendingTouchMarkerRef.current = null;
 		const t = (x / rect.width) * duration;
 		if (!Number.isNaN(t)) {
 			const newTime = Math.max(0, Math.min(duration, t));
@@ -489,6 +631,18 @@ const WaveformNavigator = React.forwardRef<
 			return;
 		}
 
+		const pending = pendingTouchMarkerRef.current;
+		if (pending) {
+			const dx = touch.clientX - pending.startX;
+			const dy = touch.clientY - pending.startY;
+			if (Math.sqrt(dx * dx + dy * dy) <= TOUCH_SLOP) {
+				// Still within slop of the initial touch — keep the marker pending.
+				return;
+			}
+			// Moved beyond slop: cancel the pending marker and fall back to scrub-seek.
+			pendingTouchMarkerRef.current = null;
+		}
+
 		const x = Math.max(0, Math.min(rect.width, touch.clientX - rect.left));
 		const t = (x / rect.width) * duration;
 		if (!Number.isNaN(t)) {
@@ -499,7 +653,12 @@ const WaveformNavigator = React.forwardRef<
 		}
 	}
 
-	function onCanvasTouchEnd() {
+	function onCanvasTouchEnd(e: React.TouchEvent<HTMLCanvasElement>) {
+		const pending = pendingTouchMarkerRef.current;
+		pendingTouchMarkerRef.current = null;
+		if (pending && e.type === 'touchend') {
+			onMarkerClick?.(pending.marker, pending.index, e);
+		}
 		setHoverX(null);
 		setHoverTime(null);
 	}

--- a/src/WaveformNavigator.tsx
+++ b/src/WaveformNavigator.tsx
@@ -7,6 +7,7 @@ import { useResponsiveWidth } from './hooks/useResponsiveWidth';
 import { useKeyboardControls } from './hooks/useKeyboardControls';
 import { WaveformControls } from './components/WaveformControls';
 import { formatTime } from './utils';
+import { hitTestDefaultMarkerLabel } from './utils/defaultMarkerLabel';
 
 type AudioProp = string | File | null | undefined;
 
@@ -79,7 +80,7 @@ export interface Marker {
 	id?: string;
 	/** Optional custom rendering function. If not provided, uses default marker appearance. */
 	markup?: (props: MarkerRenderProps) => void;
-	/** Optional custom hit region; overrides the default hit column for this marker. */
+	/** Optional custom hit region; overrides the default label-badge hit region for this marker. */
 	hitTest?: (args: MarkerHitTestArgs) => boolean;
 }
 
@@ -149,8 +150,10 @@ export interface WaveformNavigatorProps {
 		event: React.MouseEvent | React.TouchEvent
 	) => void;
 	/**
-	 * Half-width in CSS px of the default full-height hit column around each marker.
-	 * @default 12
+	 * Extra padding in CSS px around the default M1/M2/… label badge hit region.
+	 * The stem below the label is not part of the default hit target, so waveform
+	 * clicks near markers can still seek.
+	 * @default 2
 	 */
 	markerHitRadius?: number;
 	/**
@@ -288,7 +291,7 @@ const WaveformNavigator = React.forwardRef<
 		styles = {},
 		markers = [],
 		onMarkerClick,
-		markerHitRadius = 12,
+		markerHitRadius = 2,
 		onMarkerHover,
 		precomputedPeaks,
 		peakComputationWidth = 1400,
@@ -506,7 +509,14 @@ const WaveformNavigator = React.forwardRef<
 			const markerX = (marker.time / duration) * rectWidth;
 			const hit = marker.hitTest
 				? marker.hitTest({ x, y, markerX, width: rectWidth, height: rectHeight })
-				: Math.abs(x - markerX) <= markerHitRadius;
+				: hitTestDefaultMarkerLabel({
+						x,
+						y,
+						markerX,
+						index,
+						canvasWidth: rectWidth,
+						hitPadding: markerHitRadius,
+					});
 
 			if (!hit) {
 				return;

--- a/src/__tests__/WaveformNavigator.markerClick.test.tsx
+++ b/src/__tests__/WaveformNavigator.markerClick.test.tsx
@@ -92,7 +92,7 @@ describe('WaveformNavigator marker click/hit-testing', () => {
 		expect(onCurrentTimeChange).not.toHaveBeenCalled();
 	});
 
-	it('clicking outside all hit columns seeks as before', async () => {
+	it('clicking outside all marker labels seeks as before', async () => {
 		mockAudio();
 		const onCurrentTimeChange = vi.fn();
 		const onMarkerClick = vi.fn();
@@ -114,13 +114,44 @@ describe('WaveformNavigator marker click/hit-testing', () => {
 		await waitForDuration(container, 120);
 
 		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
-		// Marker is at x=100, far outside the default 12px hit radius
+		// Marker is at x=100, far outside the default label hit region
 		fireEvent.click(canvas, { clientX: 10, clientY: 10 });
 
 		expect(onMarkerClick).not.toHaveBeenCalled();
 		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
 		const seekedTo = onCurrentTimeChange.mock.calls[0][0] as number;
 		expect(Math.abs(seekedTo - 6)).toBeLessThan(1);
+	});
+
+	it('clicking the stem below the default label seeks instead of firing onMarkerClick', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerClick = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		// Label occupies y≈8–28; click the stem well below it at the marker x
+		fireEvent.click(canvas, { clientX: 100, clientY: 40 });
+
+		expect(onMarkerClick).not.toHaveBeenCalled();
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+		const seekedTo = onCurrentTimeChange.mock.calls[0][0] as number;
+		expect(Math.abs(seekedTo - 60)).toBeLessThan(1);
 	});
 
 	it('resolves overlapping hit regions to nearest marker', async () => {
@@ -186,7 +217,7 @@ describe('WaveformNavigator marker click/hit-testing', () => {
 		expect(onMarkerClick.mock.calls[0][1]).toBe(0);
 	});
 
-	it('respects a custom hitTest that reports a hit far from the default column', async () => {
+	it('respects a custom hitTest that reports a hit far from the default label', async () => {
 		mockAudio();
 		const onMarkerClick = vi.fn();
 		const hitTest = vi.fn(() => true);
@@ -215,7 +246,7 @@ describe('WaveformNavigator marker click/hit-testing', () => {
 		expect(onMarkerClick.mock.calls[0][0]).toBe(markers[0]);
 	});
 
-	it('respects a custom hitTest that reports a miss inside the default column', async () => {
+	it('respects a custom hitTest that reports a miss inside the default label', async () => {
 		mockAudio();
 		const onCurrentTimeChange = vi.fn();
 		const onMarkerClick = vi.fn();

--- a/src/__tests__/WaveformNavigator.markerClick.test.tsx
+++ b/src/__tests__/WaveformNavigator.markerClick.test.tsx
@@ -1,0 +1,345 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, beforeEach, afterEach, expect, it } from 'vitest';
+
+import WaveformNavigator from '../WaveformNavigator';
+import type { Marker } from '../WaveformNavigator';
+
+const CANVAS_RECT = {
+	left: 0,
+	top: 0,
+	width: 200,
+	height: 50,
+	right: 200,
+	bottom: 50,
+	x: 0,
+	y: 0,
+} as DOMRect;
+
+function mockAudio() {
+	(global as any).Audio = function () {
+		const el = document.createElement('audio');
+		(window as any).__lastAudio = el;
+		return el;
+	};
+}
+
+async function waitForAudio() {
+	await waitFor(() => expect((window as any).__lastAudio).toBeTruthy());
+	return (window as any).__lastAudio as HTMLAudioElement;
+}
+
+async function setDuration(audioEl: HTMLAudioElement, duration: number) {
+	Object.defineProperty(audioEl, 'duration', {
+		value: duration,
+		configurable: true,
+	});
+	audioEl.dispatchEvent(new Event('loadedmetadata'));
+}
+
+async function waitForDuration(container: HTMLElement, duration: number) {
+	await waitFor(() => {
+		const el = container.querySelector('.waveform-interactive');
+		if (el?.getAttribute('aria-valuemax') !== String(duration)) {
+			throw new Error('duration not applied yet');
+		}
+	});
+}
+
+describe('WaveformNavigator marker click/hit-testing', () => {
+	const origAudio = (global as any).Audio;
+	const origGetBounding = HTMLCanvasElement.prototype.getBoundingClientRect;
+
+	beforeEach(() => {
+		HTMLCanvasElement.prototype.getBoundingClientRect = () => CANVAS_RECT;
+	});
+
+	afterEach(() => {
+		(global as any).Audio = origAudio;
+		HTMLCanvasElement.prototype.getBoundingClientRect = origGetBounding;
+	});
+
+	// duration = 120s, width = 200px → 1s = 200/120 ≈ 1.667px
+	// marker at time=60 → markerX = 100
+
+	it('clicking at a marker x fires onMarkerClick with the right marker/index and does not seek', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerClick = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.click(canvas, { clientX: 100, clientY: 10 });
+
+		expect(onMarkerClick).toHaveBeenCalledTimes(1);
+		expect(onMarkerClick.mock.calls[0][0]).toBe(markers[0]);
+		expect(onMarkerClick.mock.calls[0][1]).toBe(0);
+		expect(onCurrentTimeChange).not.toHaveBeenCalled();
+	});
+
+	it('clicking outside all hit columns seeks as before', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerClick = vi.fn();
+		const markers: Marker[] = [{ time: 60 }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		// Marker is at x=100, far outside the default 12px hit radius
+		fireEvent.click(canvas, { clientX: 10, clientY: 10 });
+
+		expect(onMarkerClick).not.toHaveBeenCalled();
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+		const seekedTo = onCurrentTimeChange.mock.calls[0][0] as number;
+		expect(Math.abs(seekedTo - 6)).toBeLessThan(1);
+	});
+
+	it('resolves overlapping hit regions to nearest marker', async () => {
+		mockAudio();
+		const onMarkerClick = vi.fn();
+		// markerX for time=59 → (59/120)*200 ≈ 98.33; for time=61 → ≈101.67
+		const markers: Marker[] = [
+			{ time: 59, id: 'far' },
+			{ time: 61, id: 'near' },
+		];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		// click closer to the second marker (x=101, second marker at ~101.67, first at ~98.33)
+		fireEvent.click(canvas, { clientX: 101, clientY: 10 });
+
+		expect(onMarkerClick).toHaveBeenCalledTimes(1);
+		expect(onMarkerClick.mock.calls[0][0]).toBe(markers[1]);
+		expect(onMarkerClick.mock.calls[0][1]).toBe(1);
+	});
+
+	it('resolves ties to the lowest array index', async () => {
+		mockAudio();
+		const onMarkerClick = vi.fn();
+		// Both markers land at the exact same x (time=60 → x=100)
+		const markers: Marker[] = [
+			{ time: 60, id: 'a' },
+			{ time: 60, id: 'b' },
+		];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.click(canvas, { clientX: 100, clientY: 10 });
+
+		expect(onMarkerClick).toHaveBeenCalledTimes(1);
+		expect(onMarkerClick.mock.calls[0][0]).toBe(markers[0]);
+		expect(onMarkerClick.mock.calls[0][1]).toBe(0);
+	});
+
+	it('respects a custom hitTest that reports a hit far from the default column', async () => {
+		mockAudio();
+		const onMarkerClick = vi.fn();
+		const hitTest = vi.fn(() => true);
+		// marker at time=10 → markerX ≈ 16.67, far from click at x=180
+		const markers: Marker[] = [{ time: 10, hitTest }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.click(canvas, { clientX: 180, clientY: 10 });
+
+		expect(hitTest).toHaveBeenCalled();
+		expect(onMarkerClick).toHaveBeenCalledTimes(1);
+		expect(onMarkerClick.mock.calls[0][0]).toBe(markers[0]);
+	});
+
+	it('respects a custom hitTest that reports a miss inside the default column', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerClick = vi.fn();
+		const hitTest = vi.fn(() => false);
+		// marker at time=60 → markerX = 100, click right on top of it
+		const markers: Marker[] = [{ time: 60, hitTest }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.click(canvas, { clientX: 100, clientY: 10 });
+
+		expect(hitTest).toHaveBeenCalled();
+		expect(onMarkerClick).not.toHaveBeenCalled();
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+	});
+
+	it('regression: with no onMarkerClick prop, a click at a marker x seeks as before', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const markers: Marker[] = [{ time: 60 }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				markers={markers}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.click(canvas, { clientX: 100, clientY: 10 });
+
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+		const seekedTo = onCurrentTimeChange.mock.calls[0][0] as number;
+		expect(Math.abs(seekedTo - 60)).toBeLessThan(1);
+	});
+
+	it('touch tap on a marker fires onMarkerClick without seeking', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerClick = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+
+		fireEvent.touchStart(canvas, { touches: [{ clientX: 100, clientY: 10 }] });
+		expect(onCurrentTimeChange).not.toHaveBeenCalled();
+
+		fireEvent.touchEnd(canvas, { touches: [] });
+
+		expect(onMarkerClick).toHaveBeenCalledTimes(1);
+		expect(onMarkerClick.mock.calls[0][0]).toBe(markers[0]);
+		expect(onMarkerClick.mock.calls[0][1]).toBe(0);
+		expect(onCurrentTimeChange).not.toHaveBeenCalled();
+	});
+
+	it('touch drag starting on a marker cancels the pending marker and falls back to scrub-seek', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerClick = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				markers={markers}
+				onMarkerClick={onMarkerClick}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+
+		fireEvent.touchStart(canvas, { touches: [{ clientX: 100, clientY: 10 }] });
+		expect(onCurrentTimeChange).not.toHaveBeenCalled();
+
+		// Move well beyond the ~10px slop
+		fireEvent.touchMove(canvas, { touches: [{ clientX: 160, clientY: 10 }] });
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+
+		fireEvent.touchEnd(canvas, { touches: [] });
+
+		// The pending marker was cancelled by the drag, so no click should fire
+		expect(onMarkerClick).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/WaveformNavigator.markerClick.test.tsx
+++ b/src/__tests__/WaveformNavigator.markerClick.test.tsx
@@ -304,6 +304,65 @@ describe('WaveformNavigator marker click/hit-testing', () => {
 		expect(Math.abs(seekedTo - 60)).toBeLessThan(1);
 	});
 
+	it('with only onMarkerHover, clicking a marker still seeks as before', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60 }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				onMarkerHover={onMarkerHover}
+				markers={markers}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.click(canvas, { clientX: 100, clientY: 10 });
+
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+		const seekedTo = onCurrentTimeChange.mock.calls[0][0] as number;
+		expect(Math.abs(seekedTo - 60)).toBeLessThan(1);
+	});
+
+	it('does not hit-test markers that are off-canvas', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerClick = vi.fn();
+		const hitTest = vi.fn(() => true);
+		const markers: Marker[] = [{ time: 130, hitTest }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				onMarkerClick={onMarkerClick}
+				markers={markers}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.click(canvas, { clientX: 180, clientY: 10 });
+
+		expect(hitTest).not.toHaveBeenCalled();
+		expect(onMarkerClick).not.toHaveBeenCalled();
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+	});
+
 	it('touch tap on a marker fires onMarkerClick without seeking', async () => {
 		mockAudio();
 		const onCurrentTimeChange = vi.fn();
@@ -372,5 +431,34 @@ describe('WaveformNavigator marker click/hit-testing', () => {
 
 		// The pending marker was cancelled by the drag, so no click should fire
 		expect(onMarkerClick).not.toHaveBeenCalled();
+	});
+
+	it('with only onMarkerHover, touching a marker still seeks as before', async () => {
+		mockAudio();
+		const onCurrentTimeChange = vi.fn();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60 }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				onCurrentTimeChange={onCurrentTimeChange}
+				onMarkerHover={onMarkerHover}
+				markers={markers}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.touchStart(canvas, { touches: [{ clientX: 100, clientY: 10 }] });
+
+		await waitFor(() => expect(onCurrentTimeChange).toHaveBeenCalled());
+		const seekedTo = onCurrentTimeChange.mock.calls[0][0] as number;
+		expect(Math.abs(seekedTo - 60)).toBeLessThan(1);
 	});
 });

--- a/src/__tests__/WaveformNavigator.markerHover.test.tsx
+++ b/src/__tests__/WaveformNavigator.markerHover.test.tsx
@@ -1,0 +1,204 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, beforeEach, afterEach, expect, it } from 'vitest';
+
+import WaveformNavigator from '../WaveformNavigator';
+import type { Marker } from '../WaveformNavigator';
+
+const CANVAS_RECT = {
+	left: 0,
+	top: 0,
+	width: 200,
+	height: 50,
+	right: 200,
+	bottom: 50,
+	x: 0,
+	y: 0,
+} as DOMRect;
+
+function mockAudio() {
+	(global as any).Audio = function () {
+		const el = document.createElement('audio');
+		(window as any).__lastAudio = el;
+		return el;
+	};
+}
+
+async function waitForAudio() {
+	await waitFor(() => expect((window as any).__lastAudio).toBeTruthy());
+	return (window as any).__lastAudio as HTMLAudioElement;
+}
+
+async function setDuration(audioEl: HTMLAudioElement, duration: number) {
+	Object.defineProperty(audioEl, 'duration', {
+		value: duration,
+		configurable: true,
+	});
+	audioEl.dispatchEvent(new Event('loadedmetadata'));
+}
+
+async function waitForDuration(container: HTMLElement, duration: number) {
+	await waitFor(() => {
+		const el = container.querySelector('.waveform-interactive');
+		if (el?.getAttribute('aria-valuemax') !== String(duration)) {
+			throw new Error('duration not applied yet');
+		}
+	});
+}
+
+describe('WaveformNavigator onMarkerHover', () => {
+	const origAudio = (global as any).Audio;
+	const origGetBounding = HTMLCanvasElement.prototype.getBoundingClientRect;
+
+	beforeEach(() => {
+		HTMLCanvasElement.prototype.getBoundingClientRect = () => CANVAS_RECT;
+	});
+
+	afterEach(() => {
+		(global as any).Audio = origAudio;
+		HTMLCanvasElement.prototype.getBoundingClientRect = origGetBounding;
+	});
+
+	// duration = 120s, width = 200px → marker at time=60 → markerX = 100
+
+	it('fires on enter with the marker and index', async () => {
+		mockAudio();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerHover={onMarkerHover}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.mouseMove(canvas, { clientX: 100, clientY: 10 });
+
+		expect(onMarkerHover).toHaveBeenCalledTimes(1);
+		expect(onMarkerHover).toHaveBeenCalledWith(markers[0], 0);
+	});
+
+	it('fires on change when moving from one marker to another', async () => {
+		mockAudio();
+		const onMarkerHover = vi.fn();
+		// time=10 → x≈16.67, time=110 → x≈183.33
+		const markers: Marker[] = [
+			{ time: 10, id: 'a' },
+			{ time: 110, id: 'b' },
+		];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerHover={onMarkerHover}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.mouseMove(canvas, { clientX: 17, clientY: 10 });
+		fireEvent.mouseMove(canvas, { clientX: 17, clientY: 10 }); // same marker again — no extra fire
+		fireEvent.mouseMove(canvas, { clientX: 183, clientY: 10 });
+
+		expect(onMarkerHover).toHaveBeenCalledTimes(2);
+		expect(onMarkerHover.mock.calls[0]).toEqual([markers[0], 0]);
+		expect(onMarkerHover.mock.calls[1]).toEqual([markers[1], 1]);
+	});
+
+	it('fires with (null, null) when leaving a marker without leaving the canvas', async () => {
+		mockAudio();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerHover={onMarkerHover}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.mouseMove(canvas, { clientX: 100, clientY: 10 });
+		fireEvent.mouseMove(canvas, { clientX: 10, clientY: 10 });
+
+		expect(onMarkerHover).toHaveBeenCalledTimes(2);
+		expect(onMarkerHover.mock.calls[0]).toEqual([markers[0], 0]);
+		expect(onMarkerHover.mock.calls[1]).toEqual([null, null]);
+	});
+
+	it('fires with (null, null) on canvas leave', async () => {
+		mockAudio();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerHover={onMarkerHover}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.mouseMove(canvas, { clientX: 100, clientY: 10 });
+		expect(onMarkerHover).toHaveBeenCalledTimes(1);
+
+		fireEvent.mouseLeave(canvas);
+
+		expect(onMarkerHover).toHaveBeenCalledTimes(2);
+		expect(onMarkerHover.mock.calls[1]).toEqual([null, null]);
+	});
+
+	it('does not fire when the pointer never enters a marker hit region', async () => {
+		mockAudio();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerHover={onMarkerHover}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.mouseMove(canvas, { clientX: 10, clientY: 10 });
+
+		expect(onMarkerHover).not.toHaveBeenCalled();
+	});
+});

--- a/src/__tests__/WaveformNavigator.markerHover.test.tsx
+++ b/src/__tests__/WaveformNavigator.markerHover.test.tsx
@@ -201,4 +201,66 @@ describe('WaveformNavigator onMarkerHover', () => {
 
 		expect(onMarkerHover).not.toHaveBeenCalled();
 	});
+
+	it('touch start on a marker fires onMarkerHover so markup can see hovered', async () => {
+		mockAudio();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerHover={onMarkerHover}
+				onMarkerClick={() => {}}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.touchStart(canvas, { touches: [{ clientX: 100, clientY: 10 }] });
+
+		expect(onMarkerHover).toHaveBeenCalledTimes(1);
+		expect(onMarkerHover).toHaveBeenCalledWith(markers[0], 0);
+
+		fireEvent.touchEnd(canvas, { touches: [] });
+
+		expect(onMarkerHover).toHaveBeenCalledTimes(2);
+		expect(onMarkerHover.mock.calls[1]).toEqual([null, null]);
+	});
+
+	it('touch drag beyond slop clears hover when leaving a pending marker', async () => {
+		mockAudio();
+		const onMarkerHover = vi.fn();
+		const markers: Marker[] = [{ time: 60, id: 'm1' }];
+
+		const { container } = render(
+			<WaveformNavigator
+				audio="/test.mp3"
+				responsive={false}
+				controlledCurrentTime={0}
+				markers={markers}
+				onMarkerHover={onMarkerHover}
+				onMarkerClick={() => {}}
+			/>
+		);
+
+		const audioEl = await waitForAudio();
+		await act(async () => setDuration(audioEl, 120));
+		await waitForDuration(container, 120);
+
+		const canvas = container.querySelector('canvas') as HTMLCanvasElement;
+		fireEvent.touchStart(canvas, { touches: [{ clientX: 100, clientY: 10 }] });
+		expect(onMarkerHover).toHaveBeenCalledWith(markers[0], 0);
+
+		fireEvent.touchMove(canvas, { touches: [{ clientX: 160, clientY: 10 }] });
+
+		expect(onMarkerHover).toHaveBeenCalledTimes(2);
+		expect(onMarkerHover.mock.calls[1]).toEqual([null, null]);
+	});
 });

--- a/src/hooks/__tests__/useWaveformCanvas.markers.test.tsx
+++ b/src/hooks/__tests__/useWaveformCanvas.markers.test.tsx
@@ -8,10 +8,12 @@ function TestComponent({
 	markers,
 	markerColor = '#10b981',
 	markerLabelColor = '#ffffff',
+	hoveredMarkerIndex = null,
 }: {
 	markers: Marker[];
 	markerColor?: string;
 	markerLabelColor?: string;
+	hoveredMarkerIndex?: number | null;
 }) {
 	const { canvasRef } = useWaveformCanvas({
 		width: 100,
@@ -25,6 +27,7 @@ function TestComponent({
 		markerColor,
 		markerLabelColor,
 		markers,
+		hoveredMarkerIndex,
 		peaks: new Float32Array([0.5, 0.2, 0.8]),
 		currentTime: 0,
 		duration: 10,
@@ -207,5 +210,83 @@ describe('useWaveformCanvas with markers', () => {
 		expect(textCalls).toContain('M2');
 		expect(textCalls).toContain('M3');
 		expect(textCalls).toContain('M4');
+	});
+
+	it('passes the hovered flag through to custom markup', async () => {
+		const customMarkup = vi.fn();
+		const markers: Marker[] = [{ time: 5, markup: customMarkup }];
+
+		(window as any).__waveformReady = false;
+
+		render(<TestComponent markers={markers} hoveredMarkerIndex={0} />);
+
+		await waitFor(() => {
+			if (!(window as any).__waveformReady) {
+				throw new Error('not ready');
+			}
+		});
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(customMarkup).toHaveBeenCalled();
+		expect(customMarkup.mock.calls[0][0]).toHaveProperty('hovered', true);
+	});
+
+	it('reports hovered: false for markers other than the hovered index', async () => {
+		const customMarkup = vi.fn();
+		const markers: Marker[] = [
+			{ time: 2.5, markup: customMarkup },
+			{ time: 5, markup: customMarkup },
+		];
+
+		(window as any).__waveformReady = false;
+
+		render(<TestComponent markers={markers} hoveredMarkerIndex={1} />);
+
+		await waitFor(() => {
+			if (!(window as any).__waveformReady) {
+				throw new Error('not ready');
+			}
+		});
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		const hoveredFlags = customMarkup.mock.calls.map((call: any) => [
+			call[0].index,
+			call[0].hovered,
+		]);
+		expect(hoveredFlags).toContainEqual([0, false]);
+		expect(hoveredFlags).toContainEqual([1, true]);
+	});
+
+	it('triggers a redraw when hoveredMarkerIndex changes while paused', async () => {
+		const customMarkup = vi.fn();
+		const markers: Marker[] = [{ time: 5, markup: customMarkup }];
+
+		(window as any).__waveformReady = false;
+
+		const { rerender } = render(
+			<TestComponent markers={markers} hoveredMarkerIndex={null} />
+		);
+
+		await waitFor(() => {
+			if (!(window as any).__waveformReady) {
+				throw new Error('not ready');
+			}
+		});
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(customMarkup).toHaveBeenCalled();
+		const callsBefore = customMarkup.mock.calls.length;
+		expect(customMarkup.mock.calls[callsBefore - 1][0]).toHaveProperty(
+			'hovered',
+			false
+		);
+
+		rerender(<TestComponent markers={markers} hoveredMarkerIndex={0} />);
+
+		await waitFor(() => {
+			expect(customMarkup.mock.calls.length).toBeGreaterThan(callsBefore);
+		});
+		const lastCall = customMarkup.mock.calls[customMarkup.mock.calls.length - 1];
+		expect(lastCall[0]).toHaveProperty('hovered', true);
 	});
 });

--- a/src/hooks/useWaveformCanvas.ts
+++ b/src/hooks/useWaveformCanvas.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from 'react';
 import { syncCanvasSize } from '../utils';
+import {
+	DEFAULT_MARKER_LABEL_FONT,
+	DEFAULT_MARKER_LABEL_HEIGHT,
+	DEFAULT_MARKER_LABEL_PAD_X,
+	DEFAULT_MARKER_LABEL_Y,
+} from '../utils/defaultMarkerLabel';
 import type { Marker } from '../WaveformNavigator';
 
 interface UseWaveformCanvasProps {
@@ -259,16 +265,16 @@ export function useWaveformCanvas({
 
 				// Draw label background and text
 				const label = `M${index + 1}`;
-				ctx.font = '12px sans-serif';
+				ctx.font = DEFAULT_MARKER_LABEL_FONT;
 				const textMetrics = ctx.measureText(label);
-				const labelWidth = textMetrics.width + 8;
-				const labelHeight = 20;
+				const labelWidth = textMetrics.width + DEFAULT_MARKER_LABEL_PAD_X;
+				const labelHeight = DEFAULT_MARKER_LABEL_HEIGHT;
 				// Clamp label position to stay within canvas bounds
 				const labelX = Math.max(
 					0,
 					Math.min(canvasWidth - labelWidth, markerX - labelWidth / 2)
 				);
-				const labelY = 8;
+				const labelY = DEFAULT_MARKER_LABEL_Y;
 
 				// Draw label background
 				ctx.fillStyle = markerColor;

--- a/src/hooks/useWaveformCanvas.ts
+++ b/src/hooks/useWaveformCanvas.ts
@@ -14,6 +14,8 @@ interface UseWaveformCanvasProps {
 	markerColor?: string;
 	markerLabelColor?: string;
 	markers?: Marker[];
+	/** Index of the marker currently hovered by the pointer, or null when none. */
+	hoveredMarkerIndex?: number | null;
 	peaks: Float32Array | null;
 	currentTime: number;
 	duration: number;
@@ -39,6 +41,7 @@ export function useWaveformCanvas({
 	markerColor = '#10b981',
 	markerLabelColor = '#ffffff',
 	markers = [],
+	hoveredMarkerIndex = null,
 	peaks,
 	currentTime,
 	duration,
@@ -62,13 +65,15 @@ export function useWaveformCanvas({
 	const currentTimeRef = useRef(currentTime);
 	const durationRef = useRef(duration);
 	const peaksRef = useRef(peaks);
+	const hoveredMarkerIndexRef = useRef(hoveredMarkerIndex);
 
 	// Keep refs updated
 	useEffect(() => {
 		currentTimeRef.current = currentTime;
 		durationRef.current = duration;
 		peaksRef.current = peaks;
-	}, [currentTime, duration, peaks]);
+		hoveredMarkerIndexRef.current = hoveredMarkerIndex;
+	}, [currentTime, duration, peaks, hoveredMarkerIndex]);
 
 	// Initialize canvas with HiDPI support
 	useEffect(() => {
@@ -202,7 +207,7 @@ export function useWaveformCanvas({
 
 		// Draw markers (using logical coordinates)
 		if (markers && markers.length > 0) {
-			drawMarkers(ctx, markers, dur, width, height);
+			drawMarkers(ctx, markers, dur, width, height, hoveredMarkerIndexRef.current);
 		}
 	}
 
@@ -215,7 +220,8 @@ export function useWaveformCanvas({
 		markersArr: Marker[],
 		dur: number,
 		canvasWidth: number,
-		canvasHeight: number
+		canvasHeight: number,
+		hoveredIndex: number | null
 	) {
 		if (dur <= 0) {
 			return;
@@ -240,6 +246,7 @@ export function useWaveformCanvas({
 					height: canvasHeight,
 					index,
 					marker,
+					hovered: index === hoveredIndex,
 				});
 				ctx.restore();
 			} else {
@@ -314,7 +321,15 @@ export function useWaveformCanvas({
 				rafRef.current = null;
 			}
 		};
-	}, [isPlaying, peaks, progressColor, playheadColor, markerColor, markerLabelColor, markers]);
+	}, [
+		isPlaying,
+		peaks,
+		progressColor,
+		playheadColor,
+		markerColor,
+		markerLabelColor,
+		markers,
+	]);
 
 	// When paused, redraw on seek or whenever any visual prop changes.
 	// Mirrors the deps the original combined effect used for the non-playing branch,
@@ -323,7 +338,17 @@ export function useWaveformCanvas({
 		if (!isPlaying && peaks) {
 			drawWaveform(peaks, currentTime);
 		}
-	}, [currentTime, isPlaying, peaks, progressColor, playheadColor, markerColor, markerLabelColor, markers]);
+	}, [
+		currentTime,
+		isPlaying,
+		peaks,
+		progressColor,
+		playheadColor,
+		markerColor,
+		markerLabelColor,
+		markers,
+		hoveredMarkerIndex,
+	]);
 
 	return {
 		canvasRef,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	WaveformNavigatorHandle,
 	WaveformNavigatorStyles,
 	Marker,
+	MarkerHitTestArgs,
 	MarkerRenderProps,
 	RenderButtonsProps,
 } from './WaveformNavigator';

--- a/src/utils/__tests__/defaultMarkerLabel.test.ts
+++ b/src/utils/__tests__/defaultMarkerLabel.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import {
+	DEFAULT_MARKER_LABEL_HEIGHT,
+	DEFAULT_MARKER_LABEL_Y,
+	getDefaultMarkerLabelRect,
+	hitTestDefaultMarkerLabel,
+} from '../defaultMarkerLabel';
+
+describe('defaultMarkerLabel', () => {
+	it('centers the label on markerX and clamps to the canvas', () => {
+		const mid = getDefaultMarkerLabelRect(100, 0, 200);
+		expect(mid.y).toBe(DEFAULT_MARKER_LABEL_Y);
+		expect(mid.height).toBe(DEFAULT_MARKER_LABEL_HEIGHT);
+		expect(mid.x).toBeCloseTo(100 - mid.width / 2);
+
+		const left = getDefaultMarkerLabelRect(2, 0, 200);
+		expect(left.x).toBe(0);
+
+		const right = getDefaultMarkerLabelRect(198, 0, 200);
+		expect(right.x + right.width).toBe(200);
+	});
+
+	it('hits only the label badge, not the stem below', () => {
+		const args = {
+			markerX: 100,
+			index: 0,
+			canvasWidth: 200,
+			hitPadding: 0,
+		};
+
+		expect(
+			hitTestDefaultMarkerLabel({ ...args, x: 100, y: 18 })
+		).toBe(true);
+		expect(
+			hitTestDefaultMarkerLabel({ ...args, x: 100, y: 40 })
+		).toBe(false);
+		expect(
+			hitTestDefaultMarkerLabel({ ...args, x: 10, y: 18 })
+		).toBe(false);
+	});
+
+	it('expands the hit region by hitPadding', () => {
+		const rect = getDefaultMarkerLabelRect(100, 0, 200);
+		expect(
+			hitTestDefaultMarkerLabel({
+				x: rect.x - 2,
+				y: rect.y - 2,
+				markerX: 100,
+				index: 0,
+				canvasWidth: 200,
+				hitPadding: 2,
+			})
+		).toBe(true);
+	});
+});

--- a/src/utils/defaultMarkerLabel.ts
+++ b/src/utils/defaultMarkerLabel.ts
@@ -1,0 +1,62 @@
+/**
+ * Geometry for the default M1 / M2 / … label badge.
+ * Kept in sync between canvas drawing and default hit-testing.
+ */
+export const DEFAULT_MARKER_LABEL_Y = 8;
+export const DEFAULT_MARKER_LABEL_HEIGHT = 20;
+export const DEFAULT_MARKER_LABEL_PAD_X = 8;
+export const DEFAULT_MARKER_LABEL_FONT = '12px sans-serif';
+
+/**
+ * Approximate `measureText` width for `12px sans-serif` "M{n}" plus horizontal padding.
+ * Used when a canvas context is unavailable (hit-testing).
+ */
+export function estimateDefaultMarkerLabelWidth(index: number): number {
+	const label = `M${index + 1}`;
+	// ~7.2px per glyph at 12px sans-serif covers typical Latin widths for "M" + digits
+	return label.length * 7.2 + DEFAULT_MARKER_LABEL_PAD_X;
+}
+
+export function getDefaultMarkerLabelRect(
+	markerX: number,
+	index: number,
+	canvasWidth: number,
+	labelWidth = estimateDefaultMarkerLabelWidth(index)
+): { x: number; y: number; width: number; height: number } {
+	const width = labelWidth;
+	const height = DEFAULT_MARKER_LABEL_HEIGHT;
+	const x = Math.max(0, Math.min(canvasWidth - width, markerX - width / 2));
+	const y = DEFAULT_MARKER_LABEL_Y;
+	return { x, y, width, height };
+}
+
+/**
+ * Default interactive hit region: the label badge only (not the full-height stem),
+ * so clicks on the waveform around clustered markers can still seek.
+ *
+ * `hitPadding` expands the rect slightly (from `markerHitRadius`) for easier targeting.
+ */
+export function hitTestDefaultMarkerLabel(args: {
+	x: number;
+	y: number;
+	markerX: number;
+	index: number;
+	canvasWidth: number;
+	hitPadding?: number;
+}): boolean {
+	const {
+		x,
+		y,
+		markerX,
+		index,
+		canvasWidth,
+		hitPadding = 0,
+	} = args;
+	const rect = getDefaultMarkerLabelRect(markerX, index, canvasWidth);
+	return (
+		x >= rect.x - hitPadding &&
+		x <= rect.x + rect.width + hitPadding &&
+		y >= rect.y - hitPadding &&
+		y <= rect.y + rect.height + hitPadding
+	);
+}


### PR DESCRIPTION
Added the ability for markers to be interactive. Default behaviour is unchanged. 
This allows the ability to, for instance, hover and see a comment or section markers and provide a way to have more interactivity with the parent container